### PR TITLE
UMIP test: Initial version for UMIP test.

### DIFF
--- a/umip/.gitignore
+++ b/umip/.gitignore
@@ -1,0 +1,3 @@
+*.o
+umip_exceptions_32
+umip_exceptions_64

--- a/umip/Makefile
+++ b/umip/Makefile
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0
+BIN := umip_exceptions_64 umip_exceptions_32
+
+all: $(BIN)
+
+umip_exceptions_64: umip_exceptions.c
+	$(CC) -no-pie -c umip_utils.c -o umip_utils_64.o
+	$(CC) -o $@ umip_utils_64.o $^
+
+umip_exceptions_32: umip_exceptions.c
+	$(CC) -no-pie -c umip_utils.c -m32 -o umip_utils_32.o
+	$(CC) -m32 -o $@ umip_utils_32.o $^
+
+clean:
+	rm -rf $(BIN) *.o

--- a/umip/README.md
+++ b/umip/README.md
@@ -1,0 +1,34 @@
+# User-Mode Instruction Prevention
+
+## Description
+User-Mode Instruction Prevention(UMIP) is a security feature in Intel
+Processors. The 8th generation and later Intel CPUs will support
+the UMIP feature. If UMIP is enabled and in CPL(Current Privilege Level) > 0
+environment, it verifies that execution of the instructions(SGDT, SIDT,
+SLDT, SMSW, STR) with mapped fault page should return the signal
+SIGSEGV(Segmentation Violation); above instructions with locked prefix
+opcode should return signal SIGILL(Illegal); SIDT and SGDT with illegal
+opcode should return signal SIGILL.
+
+Below instructions are protected by UMIP feature:
+* SGDT - Store Global Descriptor Table
+* SIDT - Store Interrupt Descriptor Table
+* SLDT - Store Local Descriptor Table
+* SMSW - Store Machine Status Word
+* STR  - Store Task Register
+
+## Usage
+make
+./umip_exceptions_64 a
+and
+./umip_exceptions_32 a
+It tests all 3 types of cases:
+1. Execution of the instructions(SGDT, SIDT, SLDT, SMSW, STR) with mapped fault
+   page should return the signal SIGSEGV.
+2. Execution of the instructions(SGDT, SIDT, SLDT, SMSW, STR) with locked prefix
+   opcode should return the signal SIGILL(Illegal).
+3. Execution of the instructions SGDT and SIDT with illegal opcode should return
+   the signal SIGILL.
+
+## Expected result
+All test results should show pass without fail.

--- a/umip/umip_exceptions.c
+++ b/umip/umip_exceptions.c
@@ -1,0 +1,432 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * umip_exceptions.c
+ * Contributors:
+ *      Neri, Ricardo <ricardo.neri@intel.com>
+ *      - Tested sgdt, sidt, sldt, smsw and str instructions
+ *      - test UMIP emulation code when a page fault should be
+ *      - generated (i.e., the requested memory access is not mapped. No code
+ *      - is included to test cases in which Memory Protection Keys are used.
+ *      - maperr_pf
+ *      - lock_prefix
+ *      - register_operand
+ *      Pengfei, Xu <pengfei.xu@intel.com>
+ *      - Add parameter for each instruction test and unify the code style
+ *      - Some formatting improvements
+ */
+
+/*****************************************************************************/
+
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <string.h>
+#include <ucontext.h>
+#include <err.h>
+#include <asm/ldt.h>
+#include <sys/syscall.h>
+#include "umip_test_defs.h"
+
+extern sig_atomic_t got_signal, got_sigcode;
+
+int test_passed, test_failed, test_errors;
+
+#define gen_test_maperr_pf_inst(inst, bad_addr)					\
+static void __test_maperr_pf_##inst(int exp_signum, int exp_sigcode)		\
+{										\
+	unsigned long *val_bad = (unsigned long *)bad_addr;			\
+										\
+	got_signal = 0;								\
+	got_sigcode = 0;							\
+										\
+	pr_info("Test page fault because unmapped memory for %s with addr %p\n",\
+		#inst, val_bad);						\
+	asm volatile (#inst" %0\n" NOP_SLED : "=m"(*val_bad));			\
+										\
+	check_signal(exp_signum);						\
+}
+
+gen_test_maperr_pf_inst(smsw, 0x100000)
+gen_test_maperr_pf_inst(sidt, 0x100000)
+gen_test_maperr_pf_inst(sgdt, 0x100000)
+gen_test_maperr_pf_inst(str, 0x100000)
+gen_test_maperr_pf_inst(sldt, 0x100000)
+
+static void test_maperr_pf(void)
+{
+	int exp_signum, exp_sigcode;
+	int exp_signum_str_sldt, exp_sigcode_str_sldt;
+
+	INIT_EXPECTED_SIGNAL(exp_signum, SIGSEGV, exp_sigcode, SEGV_MAPERR);
+	INIT_EXPECTED_SIGNAL_STR_SLDT(exp_signum_str_sldt, SIGSEGV,
+				      exp_sigcode_str_sldt, SEGV_MAPERR);
+
+	__test_maperr_pf_smsw(exp_signum, exp_sigcode);
+	__test_maperr_pf_sidt(exp_signum, exp_sigcode);
+	__test_maperr_pf_sgdt(exp_signum, exp_sigcode);
+	__test_maperr_pf_str(exp_signum_str_sldt, exp_sigcode_str_sldt);
+	__test_maperr_pf_sldt(exp_signum_str_sldt, exp_sigcode_str_sldt);
+}
+
+#define gen_test_lock_prefix_inst(name, inst)				\
+static void __test_lock_prefix_##name(void)				\
+{									\
+	got_signal = 0;							\
+	got_sigcode = 0;						\
+									\
+	pr_info("Test %s with lock prefix\n", #name);			\
+	/* name (%eax) with the LOCK prefix */				\
+	asm volatile(inst NOP_SLED);					\
+									\
+	inspect_signal(SIGILL, ILL_ILLOPN);				\
+}
+
+gen_test_lock_prefix_inst(SMSW, ".byte 0xf0, 0xf, 0x1, 0x20\n")
+gen_test_lock_prefix_inst(SIDT, ".byte 0xf0, 0xf, 0x1, 0x8\n")
+gen_test_lock_prefix_inst(SGDT, ".byte 0xf0, 0xf, 0x1, 0x0\n")
+gen_test_lock_prefix_inst(STR,  ".byte 0xf0, 0xf, 0x0, 0x8\n")
+gen_test_lock_prefix_inst(SLDT, ".byte 0xf0, 0xf, 0x0, 0x0\n")
+
+static void test_lock_prefix(void)
+{
+	__test_lock_prefix_SMSW();
+	__test_lock_prefix_SIDT();
+	__test_lock_prefix_SGDT();
+	__test_lock_prefix_STR();
+	__test_lock_prefix_SLDT();
+}
+
+#define gen_test_register_operand_inst(name, inst)			\
+static void __test_register_operand_##name(void)			\
+{									\
+	got_signal = 0;							\
+	got_sigcode = 0;						\
+									\
+	pr_info("Test %s with register operand\n", #name);		\
+	/* name (%eax) with the LOCK prefix */				\
+	asm volatile(inst NOP_SLED);					\
+									\
+	inspect_signal(SIGILL, ILL_ILLOPN);				\
+	return;								\
+}
+
+gen_test_register_operand_inst(SIDT, ".byte 0xf, 0x1, 0xc8\n")
+gen_test_register_operand_inst(SGDT, ".byte 0xf, 0x1, 0xc0\n")
+
+static void test_register_operand(void)
+{
+	__test_register_operand_SGDT();
+	__test_register_operand_SIDT();
+}
+
+#ifdef __x86_64__
+static void test_null_segment_selectors(void) {}
+#else
+#define gen_test_null_segment_selector(inst, reg)				\
+static void __test_null_segment_selector_##inst##_##reg(void)			\
+{										\
+	got_signal = 0;								\
+	got_sigcode = 0;							\
+										\
+	pr_info("Test using null seg sel for " #inst " with " #reg "\n");	\
+	asm volatile("push %" #reg "\n"						\
+		     "push %eax\n"						\
+		     "push %ebx\n"						\
+		     "mov $0x1000, %eax\n"					\
+		     "mov $0, %ebx\n"						\
+		     "mov %bx, %" #reg "\n"					\
+		     "smsw %" #reg ":(%eax)\n"					\
+		     NOP_SLED							\
+		     "pop %ebx\n"						\
+		     "pop %eax\n"						\
+		     "pop %" #reg "\n");					\
+										\
+	inspect_signal(SIGSEGV, SI_KERNEL);					\
+	return;									\
+}
+
+gen_test_null_segment_selector(smsw, ds)
+gen_test_null_segment_selector(smsw, es)
+gen_test_null_segment_selector(smsw, fs)
+gen_test_null_segment_selector(smsw, gs)
+gen_test_null_segment_selector(sidt, ds)
+gen_test_null_segment_selector(sidt, es)
+gen_test_null_segment_selector(sidt, fs)
+gen_test_null_segment_selector(sidt, gs)
+gen_test_null_segment_selector(sgdt, ds)
+gen_test_null_segment_selector(sgdt, es)
+gen_test_null_segment_selector(sgdt, fs)
+gen_test_null_segment_selector(sgdt, gs)
+gen_test_null_segment_selector(str, ds)
+gen_test_null_segment_selector(str, es)
+gen_test_null_segment_selector(str, fs)
+gen_test_null_segment_selector(str, gs)
+gen_test_null_segment_selector(sldt, ds)
+gen_test_null_segment_selector(sldt, es)
+gen_test_null_segment_selector(sldt, fs)
+gen_test_null_segment_selector(sldt, gs)
+
+static void test_null_segment_selectors(void)
+{
+	__test_null_segment_selector_smsw_ds();
+	__test_null_segment_selector_smsw_es();
+	__test_null_segment_selector_smsw_fs();
+#ifdef TEST_GS /* TODO: Meddling with gs breaks libc */
+	__test_null_segment_selector_smsw_gs();
+#endif
+	__test_null_segment_selector_sidt_ds();
+	__test_null_segment_selector_sidt_es();
+	__test_null_segment_selector_sidt_fs();
+#ifdef TEST_GS /* TODO: Meddling with gs breaks libc */
+	__test_null_segment_selector_sidt_gs();
+#endif
+
+	__test_null_segment_selector_sgdt_ds();
+	__test_null_segment_selector_sgdt_es();
+	__test_null_segment_selector_sgdt_fs();
+#ifdef TEST_GS /* TODO: Meddling with gs breaks libc */
+	__test_null_segment_selector_sgdt_gs();
+#endif
+
+	__test_null_segment_selector_sldt_ds();
+	__test_null_segment_selector_sldt_es();
+	__test_null_segment_selector_sldt_fs();
+	#ifdef TEST_GS /* TODO: Meddling with gs breaks libc */
+	__test_null_segment_selector_sldt_gs();
+#endif
+
+	__test_null_segment_selector_str_ds();
+	__test_null_segment_selector_str_es();
+	__test_null_segment_selector_str_fs();
+
+#ifdef TEST_GS /* TODO: Meddling with gs breaks libc */
+	__test_null_segment_selector_str_gs();
+#endif
+}
+#endif
+
+#ifdef __x86_64__
+static void test_addresses_outside_segment(void) {}
+#else
+
+#define SEGMENT_SIZE 0x1000
+#define CODE_DESC_INDEX 1
+#define DATA_DESC_INDEX 2
+
+#define RPL3 3
+#define TI_LDT 1
+
+#define SEGMENT_SELECTOR(index) (RPL3 | (TI_LDT << 2) | (index << 3))
+
+unsigned char custom_segment[SEGMENT_SIZE];
+
+static int setup_data_segments(void)
+{
+	int ret;
+	struct user_desc desc = {
+		.entry_number    = 0,
+		.base_addr       = 0,
+		.limit           = SEGMENT_SIZE,
+		.seg_32bit       = 1,
+		.contents        = 0, /* data */
+		.read_exec_only  = 0,
+		.limit_in_pages  = 0,
+		.seg_not_present = 0,
+		.useable         = 1
+	};
+
+	desc.entry_number = DATA_DESC_INDEX;
+	desc.base_addr = (unsigned long)&custom_segment;
+
+	ret = syscall(SYS_modify_ldt, 1, &desc, sizeof(desc));
+	if (ret) {
+		pr_error(test_errors, "Failed to install stack segment [%d].\n", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+#define gen_test_addresses_outside_segment(inst, sel)			\
+static void __test_addresses_outside_segment_##inst##_##sel(void)	\
+{									\
+	int ret;							\
+	unsigned short seg_sel;						\
+									\
+	got_signal = 0;							\
+	got_sigcode = 0;						\
+									\
+									\
+	seg_sel = SEGMENT_SELECTOR(DATA_DESC_INDEX);			\
+									\
+	pr_info("Test address outside of segment limit for " #inst " with " #sel"\n");\
+	asm volatile("push %%" #sel"\n"					\
+		     "push %%eax\n"					\
+		     "push %%ebx\n"					\
+		     "mov $0x2000, %%eax\n"				\
+		     "mov %0, %%" #sel "\n"				\
+		     #inst " %%" #sel ":(%%eax)\n"			\
+		     NOP_SLED						\
+		     "pop %%ebx\n"					\
+		     "pop %%eax\n"					\
+		     "pop %%" #sel "\n"					\
+		     :							\
+		     : "m" (seg_sel));					\
+									\
+	inspect_signal(SIGSEGV, SI_KERNEL);				\
+	return;								\
+}
+
+gen_test_addresses_outside_segment(smsw, ds)
+gen_test_addresses_outside_segment(str, ds)
+gen_test_addresses_outside_segment(sldt, ds)
+gen_test_addresses_outside_segment(sgdt, ds)
+gen_test_addresses_outside_segment(sidt, ds)
+gen_test_addresses_outside_segment(smsw, es)
+gen_test_addresses_outside_segment(str, es)
+gen_test_addresses_outside_segment(sldt, es)
+gen_test_addresses_outside_segment(sgdt, es)
+gen_test_addresses_outside_segment(sidt, es)
+gen_test_addresses_outside_segment(smsw, fs)
+gen_test_addresses_outside_segment(str, fs)
+gen_test_addresses_outside_segment(sldt, fs)
+gen_test_addresses_outside_segment(sgdt, fs)
+gen_test_addresses_outside_segment(sidt, fs)
+gen_test_addresses_outside_segment(smsw, gs)
+gen_test_addresses_outside_segment(str, gs)
+gen_test_addresses_outside_segment(sldt, gs)
+gen_test_addresses_outside_segment(sgdt, gs)
+gen_test_addresses_outside_segment(sidt, gs)
+
+static void test_addresses_outside_segment(void)
+{
+	int ret;
+
+	ret = setup_data_segments();
+	if (ret)
+		return;
+
+	__test_addresses_outside_segment_smsw_ds();
+	__test_addresses_outside_segment_str_ds();
+	__test_addresses_outside_segment_sgdt_ds();
+	__test_addresses_outside_segment_sidt_ds();
+	__test_addresses_outside_segment_sldt_ds();
+	__test_addresses_outside_segment_smsw_es();
+	__test_addresses_outside_segment_str_es();
+	__test_addresses_outside_segment_sgdt_es();
+	__test_addresses_outside_segment_sidt_es();
+	__test_addresses_outside_segment_sldt_es();
+	__test_addresses_outside_segment_smsw_fs();
+	__test_addresses_outside_segment_str_fs();
+	__test_addresses_outside_segment_sgdt_fs();
+	__test_addresses_outside_segment_sidt_fs();
+	__test_addresses_outside_segment_sldt_fs();
+#ifdef TEST_GS
+	__test_addresses_outside_segment_smsw_gs();
+	__test_addresses_outside_segment_str_gs();
+	__test_addresses_outside_segment_sgdt_gs();
+	__test_addresses_outside_segment_sidt_gs();
+	__test_addresses_outside_segment_sldt_gs();
+#endif
+}
+#endif
+
+void usage(void)
+{
+	printf("Usage: [m][l][r][n][d][a]\n");
+	printf("m      Test test_maperr_pf\n");
+	printf("l      Test test_lock_prefix\n");
+	printf("r      Test test_register_operand\n");
+	printf("n      Test test_null_segment_selectors(TODO)\n");
+	printf("d      Test test_addresses_outside_segment(TODO)\n");
+	printf("a      Test all\n");
+}
+
+int main(int argc, char *argv[])
+{
+	struct sigaction action;
+	int ret;
+
+	PRINT_BITNESS;
+
+	memset(&action, 0, sizeof(action));
+	action.sa_sigaction = &signal_handler;
+	action.sa_flags = SA_SIGINFO;
+	sigemptyset(&action.sa_mask);
+	char parm;
+
+	if (argc == 1) {
+		usage();
+		exit(1);
+	} else {
+		ret = sscanf(argv[1], "%c", &parm);
+		if (ret != 1) {
+			printf("argv[2]:%c is not a char value.\n", argv[2]);
+			return 2;
+		}
+		sscanf(argv[1], "%c", &parm);
+		pr_info("Only get 1st parameter: parm=%c\n", parm);
+	}
+
+	if (sigaction(SIGSEGV, &action, NULL) < 0) {
+		pr_error(test_errors, "Could not set the signal handler for SIGSEGV!\n");
+		exit(1);
+	}
+
+	if (sigaction(SIGILL, &action, NULL) < 0) {
+		pr_error(test_errors, "Could not set signal handler SIGILL!\n");
+		exit(1);
+	}
+
+	switch (parm) {
+	case 'a':
+		pr_info("Test all.\n");
+		pr_info("***Test test_maperr_pf next***\n");
+		test_maperr_pf();
+		pr_info("***Test test_lock_prefix next***\n");
+		test_lock_prefix();
+		pr_info("***Test test_register_operand next***\n");
+		test_register_operand();
+		pr_info("***Test test_null_segment_selectors***\n");
+		test_null_segment_selectors();
+		pr_info("***Test test_addresses_outside_segment***\n");
+		test_addresses_outside_segment();
+		break;
+	case 'm':
+		pr_info("***Test test_maperr_pf next***\n");
+		test_maperr_pf();
+		break;
+	case 'l':
+		pr_info("***Test test_lock_prefix***\n");
+		test_lock_prefix();
+		break;
+	case 'r':
+		pr_info("***Test test_register_operand***\n");
+		test_register_operand();
+		break;
+	default:
+		usage();
+		exit(1);
+	}
+
+	memset(&action, 0, sizeof(action));
+	action.sa_handler = SIG_DFL;
+	sigemptyset(&action.sa_mask);
+
+	if (sigaction(SIGSEGV, &action, NULL) < 0) {
+		pr_error(test_errors, "Could not remove signal SIGSEGV handler!\n");
+		print_results();
+		return 1;
+	}
+
+	if (sigaction(SIGILL, &action, NULL) < 0) {
+		pr_error(test_errors, "Could not remove signal SIGILL handler!\n");
+		print_results();
+		return 1;
+	}
+
+	print_results();
+	return 0;
+}

--- a/umip/umip_test_defs.h
+++ b/umip/umip_test_defs.h
@@ -1,0 +1,138 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef _UMIP_TEST_DEFS_H
+#define _UMIP_TEST_DEFS_H
+#include <stdio.h>
+#include <signal.h>
+
+#define TEST_PASS "\x1b[32m[pass]\x1b[0m "
+#define TEST_FAIL "\x1b[31m[FAIL]\x1b[0m "
+#define TEST_INFO "\x1b[34m[info]\x1b[0m "
+#define TEST_ERROR "\x1b[33m[ERROR]\x1b[0m "
+
+#define pr_pass(pass_ctr, ...) do {			\
+	printf(TEST_PASS __VA_ARGS__); pass_ctr++;	\
+} while (0)
+#define pr_fail(fail_ctr, ...) do {	\
+	printf(TEST_FAIL __VA_ARGS__);	\
+	fail_ctr++;			\
+} while (0)
+#define pr_info(...) printf(TEST_INFO __VA_ARGS__)
+#define pr_error(error_ctr, ...) do {			\
+	printf(TEST_ERROR __VA_ARGS__); error_ctr++;	\
+} while (0)
+
+/*
+ * Use this definiton to check for results that fit in a single variable
+ * (e.g., char, short, int, long, double)
+ */
+#define pr_result(result, expected, text, pass_ctr, fail_ctr)		\
+	do {								\
+		if (result == expected)					\
+			pr_pass(pass_ctr, text);			\
+		else							\
+			pr_fail(fail_ctr, text);			\
+		printf("Got:[0x%x]Exp[0x%x]\n", result, expected);	\
+	} while (0)
+
+/*
+ * Use this definiton to check for results that in struct table_desc
+ * (e.g., char, short, int, long, double)
+ */
+#define pr_result_table(result, expected, text, pass_ctr, fail_ctr)	\
+	do {								\
+		result->base = result->base & 0xfffffffful;		\
+		if ((result->base == expected->base) &&			\
+		    (result->limit == expected->limit))			\
+			pr_pass(pass_ctr, text);			\
+		else							\
+			pr_fail(fail_ctr, text);			\
+		printf("Got:Base[0x%lx]Limit[0x%x]ExpBase[0x%lx]Limit[0x%x]\n", \
+			got->base, got->limit,				\
+			expected->base, expected->limit);		\
+	} while (0)
+
+#ifdef __x86_64__
+#define PRINT_BITNESS pr_info("This binary uses 64-bit code\n")
+#define INIT_VAL(val) (0x##val##val)
+#else
+#define PRINT_BITNESS pr_info("This binary uses 32-bit code\n")
+#define INIT_VAL(val) (0x##val)
+#endif
+
+#define EXPECTED_SMSW 0x80050033
+#define EXPECTED_SLDT 0x0
+#define EXPECTED_STR 0x0
+#define EXPECTED_GDT_BASE 0xfffe0000
+#define EXPECTED_GDT_LIMIT 0x0
+#define EXPECTED_IDT_BASE 0xffff0000
+#define EXPECTED_IDT_LIMIT 0x0
+
+/*
+ * EMULATE_ALL implies that all the UMIP-protected instructions are emulated.
+ * If not defined, the following rules apply:
+ *  + UMIP-protected instructions are not emulated for 64-bit processes. This
+ *    means that we always should get a SIGSEGV signal with code SI_KERNEL.
+ *  + In 32-bit processes, only SGDT, SIDT and SMSW are emulated, STR and
+ *    SLDT should cause a SIGSEGV signal with code SI_CODE.
+ */
+#ifdef EMULATE_ALL
+#define INIT_EXPECTED_SIGNAL(signum, exp_signum, sigcode, exp_sigcode)	\
+	do {								\
+		signum = exp_signum;					\
+		sigcode = exp_sigcode;					\
+	} while (0)
+#else /* EMULATE_ALL */
+#ifdef __x86_64__
+#define INIT_EXPECTED_SIGNAL(signum, exp_signum, sigcode, exp_sigcode)	\
+	do {								\
+		signum = SIGSEGV;					\
+		sigcode = SI_KERNEL;					\
+	} while (0)
+#else /* __x86_64__ */
+#define INIT_EXPECTED_SIGNAL(signum, exp_signum, sigcode, exp_sigcode)	\
+	do {								\
+		signum = exp_signum;					\
+		sigcode = exp_sigcode;					\
+	} while (0)
+#endif /* __x86_64__ */
+#endif /* EMULATE_ALL */
+
+#ifdef EMULATE_ALL
+#define INIT_EXPECTED_SIGNAL_STR_SLDT(signum, exp_signum, sigcode, exp_sigcode)	\
+	INIT_EXPECTED_SIGNAL(signum, exp_signum, sigcode, exp_sigcode)
+#else
+#define INIT_EXPECTED_SIGNAL_STR_SLDT(signum, exp_signum, sigcode, exp_sigcode)	\
+	INIT_EXPECTED_SIGNAL(signum, SIGSEGV, sigcode, SI_KERNEL)
+#endif
+
+#define NOP_SLED "nop\nnop\nnop\nnop\nnop\nnop\nnop\n"	\
+		 "nop\nnop\nnop\nnop\nnop\nnop\nnop\n"
+
+/* Won't use __packed due to libc issue and it causes ldt case to fail */
+struct table_desc {
+	unsigned short limit;
+	unsigned long base;
+} __attribute__((packed));
+
+static const unsigned long expected_msw = EXPECTED_SMSW;
+static const unsigned long expected_ldt = EXPECTED_SLDT;
+static const unsigned long expected_tr = EXPECTED_STR;
+
+static const struct table_desc expected_gdt = {
+	.limit = EXPECTED_GDT_LIMIT,
+	.base = EXPECTED_GDT_BASE
+};
+
+static const struct table_desc expected_idt = {
+	.limit = EXPECTED_IDT_LIMIT,
+	.base = EXPECTED_IDT_BASE
+};
+
+void print_results(void);
+int kver_cmp(int major, int minor);
+int unexpected_signal(void);
+int check_signal(int exp_signum);
+int inspect_signal(int exp_signum, int exp_sigcode);
+void signal_handler(int signum, siginfo_t *info, void *ctx_void);
+
+#endif /* _UMIP_TEST_DEFS_H */

--- a/umip/umip_utils.c
+++ b/umip/umip_utils.c
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Contributors:
+ *      Neri, Ricardo <ricardo.neri@intel.com>
+ *      - Use: assistant for Intel User-Mode Execution Prevention
+ *      - 0 no exit on signal
+ *      - 1 receiving a signal means the test failed
+ *      - 2 receiving a signal means the test passed
+ *      Pengfei, Xu <pengfei.xu@intel.com>
+ *      - Some formatting improvements
+ *      - A kernel bug was found and now fixed, it caused umip test to go into
+ *        an infinite loop, so add 1000 loop checks to avoid the infinite loop
+ *        problem.
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <ucontext.h>
+#include <ctype.h>
+#include <sys/utsname.h>
+#include "umip_test_defs.h"
+
+extern int test_passed, test_failed, test_errors;
+static int step_add;
+void (*cleanup)(void) = NULL;
+sig_atomic_t got_signal, got_sigcode;
+
+/*
+ * Use:
+ * 0 no exit on signal
+ * 1 receiving a signal means the test failed
+ * 2 receiving a signal means the test passed
+ */
+int exit_on_signal;
+
+void print_results(void)
+{
+	printf("RESULTS: passed[%d], failed[%d], errors[%d].\n",
+	       test_passed, test_failed, test_errors);
+}
+
+/*
+ * use:
+ * 0: kernel version is or newer than target
+ * 1: kernel version is older than target
+ * 2: could not get kernel version by uname
+ */
+int kver_cmp(int major, int minor)
+{
+	struct utsname buffer;
+	char *p;
+	long ver[16] = {0};
+	int i = 0;
+
+	if (uname(&buffer) != 0) {
+		pr_fail(test_failed, "get uname failed\n");
+		return 2;
+	}
+	p = buffer.release;
+
+	while (*p) {
+		if (isdigit(*p)) {
+			ver[i] = strtol(p, &p, 10);
+			i++;
+		} else {
+			p++;
+		}
+	}
+	pr_info("Kernel major:%ld, minor:%ld\n", ver[0], ver[1]);
+	if (ver[0] < major) {
+		pr_info("major version %ld older than target %d\n", ver[0], major);
+		return 1;
+	} else if (ver[0] == major) {
+		if (ver[1] < minor) {
+			pr_info("minor version %ld older than target %d\n", ver[1], minor);
+			return 1;
+		}
+	}
+	pr_info("Kernel version is or newer than target v%d.%d\n", major, minor);
+	return 0;
+}
+
+/*
+ * Use:
+ * 0 no signal should be received as expected, pass
+ * 1 received unexpected signal, and show it's sig num and sig code
+ */
+int unexpected_signal(void)
+{
+	if (got_signal) {
+		pr_fail(test_failed, "Received unexpected signal:[%d], sigcode:[%d]\n",
+			got_signal, got_sigcode);
+		return 0;
+	}
+
+	pr_pass(test_passed, "No signal received as expected.\n");
+	return 1;
+
+}
+
+int check_signal(int exp_signum)
+{
+	if (exp_signum) {
+		if (got_signal == exp_signum) {
+			pr_pass(test_passed, "Received expected signal:%d. Sig_code:%d.\n",
+				got_signal, got_sigcode);
+			return 0;
+		}
+		pr_fail(test_failed, "Received wrong signal:%d, expected sig:%d.\n",
+		got_signal, exp_signum);
+		return 1;
+	}
+	pr_fail(test_failed, "There was no signal received.\n");
+	return 1;
+}
+
+/*
+ * Inspect the contents of exp_signum and exp_sigcode to determine if they match
+ * the received got_signal signal and signal code, if any. A return value of
+ * 1 means that the test case is complete and no further action is needed (e.g.,
+ * examine values returned by instructions. A return value of 0 means that
+ * signal processing is not relevant for the caller can proceed with further
+ * test case validation.
+ */
+int inspect_signal(int exp_signum, int exp_sigcode)
+{
+	/* If we expect signal, make sure it is the one we expect. */
+	if (exp_signum) {
+		/* A signal was received, examine it */
+		if (got_signal == exp_signum) {
+			if (got_sigcode == exp_sigcode) {
+				/* All is good. Test case is complete. */
+				pr_pass(test_passed, "Received expected signal and code.\n");
+				return 1;
+			}
+			pr_fail(test_failed, "Wrong signal:%d, code:%d Expected si_code[%d].\n",
+				got_signal, got_sigcode, exp_sigcode);
+			return 1;
+		}
+		if (got_signal) {
+			/* Wrong signal */
+			pr_fail(test_failed, "Received wrong signal. Expected [%d]\n",
+			        exp_signum);
+			return 1;
+		}
+		/* signal did not come */
+		pr_fail(test_failed, "Signal [%d] was expected. Nothing received.\n",
+		        exp_signum);
+		return 1;
+	}
+	/* If no signal is expected, make sure we did not receive one */
+	if (got_signal) {
+		pr_fail(test_failed, "Received unexpected signal.\n");
+		return 1;
+	}
+	/* Signal is not relevant.*/
+	return 0;
+}
+
+void signal_handler(int signum, siginfo_t *info, void *ctx_void)
+{
+	ucontext_t *ctx = (ucontext_t *)ctx_void;
+
+	pr_info("si_signo[%d]\n", info->si_signo);
+	pr_info("si_errno[%d]\n", info->si_errno);
+	pr_info("si_code[%d]\n", info->si_code);
+	pr_info("si_addr[0x%p]\n", info->si_addr);
+
+	got_signal = signum;
+
+	if (signum == SIGSEGV) {
+		if (info->si_code == SEGV_MAPERR)
+			pr_info("Signal because of unmapped object.\n");
+		else if (info->si_code == SI_KERNEL)
+			pr_info("Signal because of #GP\n");
+		else
+			pr_info("Unknown si_code!\n");
+	} else if (signum == SIGILL) {
+		if (info->si_code == SEGV_MAPERR)
+			pr_info("Signal because of unmapped object.\n");
+		else if (info->si_code == ILL_ILLOPN)
+			pr_info("Signal because of #UD\n");
+		else
+			pr_info("Unknown si_code!\n");
+	} else {
+		pr_error(test_errors, "Received signal that I cannot handle!\n");
+		exit(1);
+	}
+
+	/* Save the signal code */
+	got_sigcode = info->si_code;
+
+	if (exit_on_signal) {
+		if (exit_on_signal == 1)
+			pr_fail(test_failed, "Whoa! I got a signal! Something went wrong!\n");
+		else if (exit_on_signal == 2)
+			pr_pass(test_passed, "I got the expected signal.\n");
+		else
+			pr_fail(test_failed, "I don't know what to do on exit.\n");
+
+		if (cleanup)
+			(*cleanup)();
+
+		exit(1);
+	}
+
+	/*
+	 * Move to the next instruction; to move, increment the instruction
+	 * pointer by 10 bytes. 10 bytes is the size of the instruction
+	 * considering two prefix bytes, two opcode bytes, one
+	 * ModRM byte, one SIB byte and 4 displacement bytes. We have
+	 * a NOP sled after the instruction to ensure we continue execution
+	 * safely in case we overestimate the size of the instruction.
+	 */
+#ifdef __x86_64__
+	ctx->uc_mcontext.gregs[REG_RIP] += 10;
+	pr_info("REG_RIP:%d, ctx->uc_mcontext.gregs[REG_RIP]:%lld, content:0x%lx\n",
+		REG_RIP, ctx->uc_mcontext.gregs[REG_RIP],
+		*(unsigned long *)ctx->uc_mcontext.gregs[REG_RIP]);
+#else
+	ctx->uc_mcontext.gregs[REG_EIP] += 10;
+	pr_info("REG_EIP:%d, ctx->uc_mcontext.gregs[REG_EIP]:%d, content:0x%lx\n",
+		REG_EIP, ctx->uc_mcontext.gregs[REG_EIP],
+		*(unsigned long *)ctx->uc_mcontext.gregs[REG_EIP]);
+#endif
+	step_add++;
+	if (step_add > 1000) {
+		pr_fail(test_failed, "uc_mcontext.gregs[REG_R/EIP] add 1000 times!\n");
+		exit(1);
+	}
+}


### PR DESCRIPTION
UMIP(User-Mode Instruction Prevention) is a security feature in Intel Processors. If UMIP is enabled, it verifies that execution of the instructions(SGDT, SIDT, SLDT, SMSW, STR) should return a sinal SEGV(Segmentation Violation) or a dummy value if CPL(Current Privilege Level) is greater than 0.

Below instructions are protected by UMIP feature:
* SGDT - Store Global Descriptor Table
* SIDT - Store Interrupt Descriptor Table
* SLDT - Store Local Descriptor Table
* SMSW - Store Machine Status Word
* STR  - Store Task Register For the detailed information, please check the README.md in umip folder.

Reviewed-by: Yi Sun <yi.sun@intel.com>
Signed-off-by: Pengfei Xu <pengfei.xu@intel.com>