### PR TITLE
CET test: Fix the compilation warning issues

### DIFF
--- a/cet/shstk_huge_page.c
+++ b/cet/shstk_huge_page.c
@@ -128,7 +128,7 @@ static int create_huge_page_ssp(void)
 	asm("movq %%rbx,%0" : "=r"(asm_ssp));
 	asm("movq %%rbp,%0" : "=r"(bp));
 
-	printf("[INFO]\trstorssp, print origin_ssp:%p(%lx) new_ssp:%lx(%lx)\n",
+	printf("[INFO]\trstorssp, print origin_ssp:%lx(%lx) new_ssp:%lx(%lx)\n",
 	       ssp_origin, *(unsigned long *)ssp_origin, new_ssp,
 	       *(unsigned long *)new_ssp);
 	printf("[INFO]\tAfter rstorssp and print twice, new ssp:%lx(%lx)\n",

--- a/cet/test_shadow_stack.c
+++ b/cet/test_shadow_stack.c
@@ -212,7 +212,7 @@ static void violate_ss(void)
 	saved_ssp = get_ssp();
 	saved_ssp_val = *(unsigned long *)saved_ssp;
 
-	printf("[INFO]\tsaved_ssp:%x, saved_ssp_val:%x\n", saved_ssp,
+	printf("[INFO]\tsaved_ssp:%lx, saved_ssp_val:%lx\n", saved_ssp,
 	       saved_ssp_val);
 	/* Corrupt shadow stack */
 	printf("[INFO]\tCorrupting shadow stack content to 0\n");

--- a/cet/wrss.c
+++ b/cet/wrss.c
@@ -124,7 +124,7 @@ static void *sigill_receive_expected(int signum, siginfo_t *info,
 		printf("[FAIL]\tError creating shadow stack: %d\n", errno);
 		exit(1);
 	}
-	printf("[INFO]\tWill write shstk from addr:%p, content:0x%x\n", shstk,
+	printf("[INFO]\tWill write shstk from addr:%p, content:0x%lx\n", shstk,
 	       *shstk);
 
 	printf("[INFO]\tEnabled write permit for SHSTK\n");
@@ -144,7 +144,7 @@ static void *sigill_receive_expected(int signum, siginfo_t *info,
 		printf("[FAIL]\twrss failed to write\n");
 		exit(1);
 	}
-	printf("[PASS]\twrss write succeded in addr:%p, content:%x\n", shstk,
+	printf("[PASS]\twrss write succeded in addr:%p, content:%lx\n", shstk,
 	       *shstk);
 
 	clearhandler(SIGILL);
@@ -164,7 +164,7 @@ int main(int argc, char *argv[])
 
 	sethandler(SIGILL, sigill_receive_expected, 0);
 	current_shstk = (unsigned long *)_get_ssp();
-	printf("[INFO]\tSHSTK addr:%p,content:0x%x, illegal to change to 1.\n",
+	printf("[INFO]\tSHSTK addr:%p,content:0x%lx, illegal to change to 1.\n",
 		current_shstk, *current_shstk);
 	write_shstk(current_shstk, 1);
 	clearhandler(SIGILL);


### PR DESCRIPTION
Fix the compilation warning issues from CET test code.

Reviewed-by: Yi Sun <yi.sun@intel.com>
Reported-by: Yi Sun <yi.sun@intel.com>
Signed-off-by: Pengfei Xu <pengfei.xu@intel.com>
