### PR TITLE
test_shadow_stack.c: update the test due to cet arch_prctl number change

### DIFF
--- a/cet/Makefile
+++ b/cet/Makefile
@@ -23,7 +23,7 @@ shstk_alloc: shstk_alloc.c
 	gcc $(CETFLAGS) $^ -o $@
 
 test_shadow_stack: test_shadow_stack.c
-	gcc $(NOCETFLAGS) $^ -o $@
+	gcc -pthread $(NOCETFLAGS) $^ -o $@
 
 quick_test: quick_test.c
 	gcc $(CETFLAGS) $^ -o $@


### PR DESCRIPTION
Because the conflict of LAM and CET arch_prctl number, cet arch_prctl number will change from 0x400x to 0x500x.
And update the test code to match latest CET user space shstk kernel. Related new update kernel link:
https://lore.kernel.org/lkml/20221104223604.29615-25-rick.p.edgecombe@intel.com/

Signed-off-by: Pengfei Xu <pengfei.xu@intel.com>