### PR TITLE
common/common.sh: move PATH exporting to .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (c) 2022 Intel Corporation.
+
+lkvs_root=$(cd "$(dirname "$0")" && pwd)
+
+if [[ -z "$path_exported" ]]; then
+  NEW_PATH="${PATH}":$(find "$lkvs_root" -type d -not -path '*.git*' | tr "\n" ":")
+  NEW_PATH=${NEW_PATH%:}
+  export PATH="$NEW_PATH"
+  path_exported=1
+fi

--- a/common/common.sh
+++ b/common/common.sh
@@ -25,20 +25,6 @@ root_check() {
 }
 root_check
 
-# set $LKVS_ROOT to use common shell libraries
-if [[ -z "$LKVS_ROOT" ]]; then
-    echo "LKVS_ROOT is not set!"
-    exit 1
-fi
-
-# Avoid that value of $PATH keeps growing when this file be sourced multiple times
-if [[ -z "$path_exported" ]]; then
-  NEW_PATH="${PATH}:$(find "$LKVS_ROOT" -type d -not -path '*.git*' | tr "\n" ":")"
-  NEW_PATH=${NEW_PATH%:}
-  export PATH="$NEW_PATH"
-  path_exported="1"
-fi
-
 TIME_FMT="%m%d_%H%M%S.%3N"
 
 # Print trace log.


### PR DESCRIPTION
This patch provides a way to append all sub directories of lkvs projects to $PATH varible. It allows developers invoking shell scripts and binaries in lkvs project directly, rather than using absolute/relative path.

Usage:
add following code to the top of scripts

  ```shell
  [[ -e "../.env" ]] && source "../.env"
  ```

Example:

  ```shell
  #!/usr/bin/env bash
  ...
  [[ -e "../.env" ]] && source "../.env"

  source common.sh

  ...
  test_print_trc "..."
  ...
  ```

Note: scripts and binaries with same names are not allowed in project scope!

Signed-off-by: Ning Han <ning.han@intel.com>