### PR TITLE
.env: functionality fixing and enhancement

### DIFF
--- a/.env
+++ b/.env
@@ -2,11 +2,12 @@
 # SPDX-License-Identifier: GPL-2.0-only
 # Copyright (c) 2022 Intel Corporation.
 
-lkvs_root=$(cd "$(dirname "$0")" && pwd)
+lkvs_root=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
 
 if [[ -z "$path_exported" ]]; then
-  NEW_PATH="${PATH}":$(find "$lkvs_root" -type d -not -path '*.git*' | tr "\n" ":")
+  NEW_PATH="$PATH":$(find "$lkvs_root" -type d -not -path '*.git*' | tr "\n" ":")
   NEW_PATH=${NEW_PATH%:}
   export PATH="$NEW_PATH"
+  source common.sh
   path_exported=1
 fi


### PR DESCRIPTION
Summary of this commit:

  1. fix functionality of adding all subdirectories to $PATH variable
  2. import all resource from common.sh

Utilize .env file in 2 ways:

1. add following line to the top of any scripts that may be called from terminal directly(assume scripts are in next level of lkvs root directory):

  ```
  $ cd "$(dirname $0)" 2> /dev/null; source ../env
  ```

2. source .env from terminal, then you can wrap any executables with the function `runtest`. It should be useful for developing new tests for lkvs.

  ```
  $ runtest "<executables>"
  ```

Signed-off-by: Ning Han <ning.han@intel.com>