### PR TITLE
wrss.c: update the test due to cet arch_prctl number change

### DIFF
--- a/cet/Makefile
+++ b/cet/Makefile
@@ -30,7 +30,7 @@ quick_test: quick_test.c
 	gcc $(CETFLAGS) $^ -o $@
 
 wrss: wrss.c
-	gcc $(SHSTKFLAGS) $^ -o $@
+	gcc $(NOCETFLAGS) $^ -o $@
 
 shstk_huge_page: shstk_huge_page.c
 	gcc $(CETFLAGS) $^ -o $@


### PR DESCRIPTION
Because the conflict of LAM and CET arch_prctl number, cet arch_prctl number will change from 0x400x to 0x500x.
And update the test code to match latest CET user space shstk kernel.

Signed-off-by: Pengfei Xu <pengfei.xu@intel.com>