### PR TITLE
Fix cstate tests

### DIFF
--- a/cstate/powermgr_cstate_tests.sh
+++ b/cstate/powermgr_cstate_tests.sh
@@ -5,7 +5,7 @@
 # @Desc     Test script to verify Intel CPU Core Cstate functionality
 # @History  Created Nov 01 2022 - Created
 
-cd "$(dirname $0)" 2>/dev/null
+cd "$(dirname "$0")" 2> /dev/null || exit
 source ../.env
 
 CPU_SYSFS_PATH="/sys/devices/system/cpu"

--- a/runtests
+++ b/runtests
@@ -30,6 +30,7 @@ err() {
 runtest() {
   local cmdline=$1
   local logfile=$2
+  local subfolder=$3
   local start
   local stop
   local duration
@@ -44,6 +45,12 @@ runtest() {
 
   set -o pipefail
   start=$(date +%s.%3N)
+
+  if [[ -z "$subfolder" ]]; then
+    echo "LKVS tests: $cmdline" >> /dev/kmsg
+  else
+    echo "LKVS tests: ${subfolder}/${cmdline}" >> /dev/kmsg
+  fi
 
   if [[ -n "$logfile" ]]; then
     eval "$cmdline |& tee -a $logfile" &
@@ -83,13 +90,20 @@ runtest() {
 runcmdfile() {
   local cmdfile=$1
   local logfile=$2
+  local subfolder=""
+
+  if [[ "$cmdfile" == *"/"* ]]; then
+    subfolder=$(echo "$cmdfile" | cut -d "/" -f 1)
+  else
+    echo "cmdfile:$cmdfile(no '/') is not in a subfolder!"
+  fi
 
   while read -r line; do
     if grep -Eq "^#.*" <<< "$line" || grep -Eq "^$" <<< "$line"; then
       continue
     fi
 
-    runtest "$line" "$logfile"
+    runtest "$line" "$logfile" "$subfolder"
   done < "$cmdfile"
 }
 


### PR DESCRIPTION
1. Fix shellcheck issue.
2. If fail to change directory to feature subfolder, we should quit current test immediately as followed code will not run correctly.