### PR TITLE
cet: Fix the long and int type mismatch issue.

### DIFF
--- a/cet/shstk_cp.c
+++ b/cet/shstk_cp.c
@@ -82,13 +82,13 @@ void shstk_violation(void)
 	asm("movq %%rbp,%0" : "=r"(rbp));
 
 	printf("[INFO]\tdo_hack() change address for return:\n");
-	printf("[INFO]\tBefore,ssp:%lx,*ssp:%lx,rbp:%p,*rbp:%lx,*(rbp+1):%lx\n",
+	printf("[INFO]\tBefore,ssp:%p,*ssp:%lx,rbp:%p,*rbp:%lx,*(rbp+1):%lx\n",
 	       ssp, *ssp, rbp, *rbp, *(rbp + 1));
 
 	/* rbp+1(8bytes) saved sp(ret ip), change rbp+1 to change sp content */
 	*(rbp + 1) = (unsigned long)hacked;
 
-	printf("[INFO]\tAfter, ssp:%lx,*ssp:%lx,rbp:%p,*rbp:%lx,*(rbp+1):%lx\n",
+	printf("[INFO]\tAfter, ssp:%p,*ssp:%lx,rbp:%p,*rbp:%lx,*(rbp+1):%lx\n",
 	       ssp, *ssp, rbp, *rbp, *(rbp + 1));
 }
 
@@ -119,7 +119,7 @@ int main(void)
 	ssp = rdssp();
 
 	if (!ssp) {
-		printf("[FAIL]\tCould not read ssp:%p.\n", ssp);
+		printf("[FAIL]\tCould not read ssp:%lx.\n", ssp);
 		return 1;
 	}
 	printf("[PASS]\tSHSTK enabled, ssp:%lx\n", ssp);

--- a/cet/shstk_unlock_test.c
+++ b/cet/shstk_unlock_test.c
@@ -133,47 +133,47 @@ long unlock_shstk(pid_t pid)
 
 	ret = ptrace(PTRACE_GETREGSET, pid, NT_X86_SHSTK, &iov_cet);
 	if (ret) {
-		printf("[FAIL]\tGETREGSET NT_X86_SHSTK fail ret:%d, errno:%d\n",
+		printf("[FAIL]\tGETREGSET NT_X86_SHSTK fail ret:%ld, errno:%d\n",
 		       ret, errno);
 		result = 1;
 	} else if (user_ssp == 0) {
-		printf("[FAIL]\tcet_ssp:%d is 0\n", user_ssp);
+		printf("[FAIL]\tcet_ssp:%ld is 0\n", user_ssp);
 		result = 1;
 	} else {
-		printf("[PASS]\tGET CET REG ret:%d, err:%d, ssp:%lx\n",
+		printf("[PASS]\tGET CET REG ret:%ld, err:%d, ssp:%lx\n",
 		       ret, errno, user_ssp);
 	}
 
 	ret = ptrace(PTRACE_SETREGSET, pid, NT_X86_SHSTK, &iov_cet);
 	if (ret) {
-		printf("[FAIL]\tSETREGSET NT_X86_SHSTK fail ret:%d, errno:%d\n",
+		printf("[FAIL]\tSETREGSET NT_X86_SHSTK fail ret:%ld, errno:%d\n",
 		       ret, errno);
 		result = 1;
 	} else if (user_ssp == 0) {
-		printf("[FAIL]\tcet_ssp:%d is 0\n", user_ssp);
+		printf("[FAIL]\tcet_ssp:%ld is 0\n", user_ssp);
 		result = 1;
 	} else {
-		printf("[PASS]\tSET CET REG ret:%d, err:%d, ssp:%lx\n",
+		printf("[PASS]\tSET CET REG ret:%ld, err:%d, ssp:%lx\n",
 		       ret, errno, user_ssp);
 	}
 
 	user_ssp = -1;
 	ret = ptrace(PTRACE_SETREGSET, pid, NT_X86_SHSTK, &iov_cet);
 	if (ret) {
-		printf("[PASS]\tSET ssp -1 failed(expected) ret:%d, errno:%d\n",
+		printf("[PASS]\tSET ssp -1 failed(expected) ret:%ld, errno:%d\n",
 		       ret, errno);
 	} else {
-		printf("[FAIL]\tSET ssp -1 ret:%d, err:%d, ssp:%lx\n",
+		printf("[FAIL]\tSET ssp -1 ret:%ld, err:%d, ssp:%lx\n",
 		       ret, errno, user_ssp);
 		result = 1;
 	}
 
 	ret = ptrace(PTRACE_GETREGSET, pid, NT_X86_XSTATE, &iov);
 	if (ret) {
-		printf("[FAIL]\tGET xstate failed ret:%d\n", ret);
+		printf("[FAIL]\tGET xstate failed ret:%ld\n", ret);
 		result = 1;
 	} else {
-		printf("[PASS]\tGET xstate successfully ret:%d\n", ret);
+		printf("[PASS]\tGET xstate successfully ret:%ld\n", ret);
 	}
 
 detach:


### PR DESCRIPTION
Fix the long and int type mismatch issue in shstk_cp.c and shstk_unlock_test.c.

Reviewed-by: Yi Sun <yi.sun@intel.com>
Signed-off-by: Pengfei Xu <pengfei.xu@intel.com>