### PR TITLE
Makefile: Bugfix: check Makefile existing before compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,17 @@
 
 SUBDIRS = $(shell ls -d */)
 all:
-	for dir in $(SUBDIRS) ; do \
-		make -C  $$dir ; \
+	for dir in $(SUBDIRS) ; do			\
+		if [ -f "$$dir/Makefile" ]; then	\
+			make -C $$dir || exit 2;	\
+		fi					\
 	done
 
 clean:
-	for dir in $(SUBDIRS) ; do \
-		make -C  $$dir clean ; \
+	for dir in $(SUBDIRS) ; do 			\
+		if [ -f "$$dir/Makefile" ]; then	\
+			make -C  $$dir clean || exit 2;	\
+		fi					\
 	done
 
 docker_image:


### PR DESCRIPTION
Makefile will check whether the sub dir has a Makefile before enter it and try to do the compiling. The compiling will be interrupted if a single sub folder failed to compile.

Signed-off-by: Yi Sun <yi.sun@intel.com>