### PR TITLE
common.sh: fix last timestamp is null bug in last_dmesg_timestamp fun…

### DIFF
--- a/common/common.sh
+++ b/common/common.sh
@@ -359,7 +359,7 @@ dmesg_pattern_check() {
 # Record last timestamp in dmesg and store the value in variable
 # LAST_DMESG_TIMESTAMP. The value is refered in function extract_case_dmesg.
 last_dmesg_timestamp() {
-  LAST_DMESG_TIMESTAMP=$(dmesg | tail -n1 | awk '{print $1}' | tr -d "[]")
+  LAST_DMESG_TIMESTAMP=$(dmesg | tail -n1 | awk -F "]" '{print $1}' | tr -d "[]")
   test_print_trc "recorded dmesg timestamp: $LAST_DMESG_TIMESTAMP"
   export LAST_DMESG_TIMESTAMP
 }


### PR DESCRIPTION
…ction

There is no issue when there is no space in last line dmesg time stamp like as below:
[11501.945229] xxxx
It could get correct time stamp "11501.945229".

If there is space in last line dmesg time stamp like as below: [ 8275.926781] xxxx
It could not get correct last line dmesg time stamp, and with null "" instead.

So correct the awk judgement to fix above last time stamp bug.

Signed-off-by: Pengfei Xu <pengfei.xu@intel.com>