### PR TITLE
Kernel space IBT: add 2 kernel space IBT test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,26 @@ apt-get update
 apt-get install gcc-11 make libelf1 gcc-multilib g++-multilib
 ```
 
+Make the driver for cet_driver:
+```
+Install the devel and headers package for target kernel and boot up
+with target kernel.
+For CentOS and so on rpm package related OS:
+rpm -ivh --force kernel-TARGET_VERSION.rpm
+rpm -ivh --force kernel-devel-TARGET_VERSION.rpm
+rpm -ivh --force kernel-headers-TARGET_VERSION.rpm
+
+For Ubuntu and so on deb package related OS:
+dpkg -i linux-xxx-image_TARGET_VERSION.deb
+dpkg -i linux-xxx-headers_TARGET_VERSION.deb
+dpkg -i linux-xxx-dev_TARGET_VERSION.deb
+dpkg -i linux-xxx-tools_TARGET_VERSION.deb
+
+Boot up with target kernel version.
+cd cet_driver
+make
+```
+
 ## Alternativly compile the whole project with Docker
 ** This is the recommended way **
 ```

--- a/cet/.gitignore
+++ b/cet/.gitignore
@@ -1,3 +1,4 @@
+cet_app
 quick_test
 shstk_alloc
 shstk_cp

--- a/cet/Makefile
+++ b/cet/Makefile
@@ -8,14 +8,24 @@ NOCETFLAGS := -O0 -fcf-protection=none -mshstk -fno-stack-check -fno-stack-prote
 GCC_VER_MAJOR := $(shell gcc --version | grep gcc | cut -d . -f1 | awk '{print $$NF}')
 GCC_GE_8 := $(shell [ $(GCC_VER_MAJOR) -ge 8 ] && echo true)
 
+KER_SRC = /lib/modules/$(shell uname -r)/build
+DRIVER_PATH = $(shell pwd)/cet_driver
+IS_KER_SRC = $(shell  [ -d $(KER_SRC) ] && echo true)
+
 ifeq ($(GCC_GE_8),true)
 BIN := shstk_alloc test_shadow_stack quick_test wrss shstk_huge_page \
-       shstk_unlock_test shstk_cp
+       shstk_unlock_test shstk_cp cet_app
 
 $(info GCC major version: ${GCC_VER_MAJOR})
 else
-$(info Warning: GCC major version ${GCC_VER_MAJOR}, older than GCC 8)
-$(info Warning: Could not handle CET related binary)
+$(info [WARN]: GCC major version ${GCC_VER_MAJOR}, older than GCC 8)
+$(info [WARN]: Could not handle CET related binary)
+endif
+
+ifeq ($(IS_KER_SRC),true)
+BIN += cet_ioctl
+else
+$(info [WARN]:No $(KER_SRC) folder, please install $(shell uname -r) devel and header package!)
 endif
 
 all: $(BIN)
@@ -41,5 +51,12 @@ shstk_unlock_test: shstk_unlock_test.c
 shstk_cp: shstk_cp.c
 	gcc $(NOCETFLAGS) $^ -o $@
 
+cet_app:
+	gcc cet_driver/cet_app.c -I cet_driver -o $@
+
+cet_ioctl:
+	$(MAKE) -C $(KER_SRC) M=$(DRIVER_PATH) modules
+
 clean:
 	rm -rf $(BIN)
+	$(MAKE) -C $(KER_SRC) M=$(DRIVER_PATH) clean

--- a/cet/cet_driver/.gitignore
+++ b/cet/cet_driver/.gitignore
@@ -1,0 +1,7 @@
+*.cmd
+*.ko
+*.o
+.tmp_versions
+cet_ioctl.mod.c
+modules.order
+Module.symvers

--- a/cet/cet_driver/Makefile
+++ b/cet/cet_driver/Makefile
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (c) 2023 Intel Corporation.
+
+# If called directly from the command line, invoke the kernel build system.
+ifeq ($(KERNELRELEASE),)
+PWD = $(shell pwd)
+RPM_PKG := $(shell rpm -qa)
+KERNEL_SOURCE = /lib/modules/$(shell uname -r)/build
+
+BIN := cet_ioctl
+
+all: $(BIN)
+
+cet_ioctl:
+	$(MAKE) -C $(KERNEL_SOURCE) M=$(PWD) modules
+
+clean:
+	$(MAKE) -C $(KERNEL_SOURCE) M=$(PWD) clean
+	${RM} -rf $(BIN)
+
+# Otherwise KERNELRELEASE is defined; we've been invoked from the
+# kernel build system and can use its language.
+else
+	obj-m := cet_ioctl.o
+endif

--- a/cet/cet_driver/cet_app.c
+++ b/cet/cet_driver/cet_app.c
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2022 Intel Corporation.
+
+/*
+ * cet_app.c
+ *
+ * This file will test cet driver with parameters
+ *      - Test CET driver app
+ */
+
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sched.h>
+#include <immintrin.h>
+#include <stdint.h>
+
+#include "cet_ioctl.h"
+
+void shstk1(int fd)
+{
+	printf("cet app try kernel space shstk, fd:%d\n", fd);
+	if (ioctl(fd, CET_SHSTK1) == -1)
+		perror("shstk return -1\n");
+}
+
+void shstk_xsaves(int fd)
+{
+	cpu_set_t set;
+
+	/* Set to cpu 0 to check ssp msr easily */
+	CPU_ZERO(&set);
+	CPU_SET(0, &set);
+	sched_setaffinity(getpid(), sizeof(set), &set);
+
+	printf("shstk xsaves test: fd:%d\n", fd);
+
+	if (ioctl(fd, CET_SHSTK_XSAVES) == -1)
+		perror("ioctl shstk xsaves return -1\n");
+}
+
+void ibt1(int fd)
+{
+	printf("cet_app try kernel ibt, fd:%d\n", fd);
+	if (ioctl(fd, CET_IBT1) == -1)
+		perror("kernel ibt return -1\n");
+}
+
+void ibt_legal(int fd)
+{
+	printf("cet_app try ibt legay function in kernel, fd:%d\n", fd);
+	if (ioctl(fd, CET_IBT2) == -1)
+		perror("kernel ibt with legal indirect jump return -1\n");
+}
+
+int main(int argc, char *argv[])
+{
+	char *file_name = "/dev/cet";
+	int fd = 0;
+	enum {
+		e_shstk1,
+		e_xsaves,
+		e_ibt1,
+		e_ibt2
+	} option;
+
+	printf("Before open, fd:%d\n", fd);
+
+	if (argc == 1) {
+		option = e_shstk1;
+	} else if (argc == 2) {
+		if (strcmp(argv[1], "s1") == 0) {
+			option = e_shstk1;
+		} else if (strcmp(argv[1], "s2") == 0) {
+			option = e_xsaves;
+		} else if (strcmp(argv[1], "b1") == 0) {
+			option = e_ibt1;
+		} else if (strcmp(argv[1], "b2") == 0) {
+			option = e_ibt2;
+		} else {
+			fprintf(stderr, "Usage:\n%s [s1 | b1]\n", argv[0]);
+			fprintf(stderr, "  s1 shstk1: trigger shstk violation in driver\n");
+			fprintf(stderr, "  s2 shstk1: xsaves and rdmsr check in ring 0\n");
+			fprintf(stderr, "  b1 ibt1: trigger ibt violation in driver\n");
+			fprintf(stderr, "  b2 ibt2: trigger ibt legacy way in driver\n");
+			return 1;
+		}
+	} else {
+		fprintf(stderr, "Usage: %s [s1 | b1]\n", argv[0]);
+		return 1;
+	}
+	fd = open(file_name, O_RDWR);
+	if (fd == -1) {
+		perror(file_name);
+		return 2;
+	}
+
+	printf("fd:%d\n", fd);
+	switch (option) {
+	case e_shstk1:
+		shstk1(fd);
+		break;
+	case e_xsaves:
+		shstk_xsaves(fd);
+		break;
+	case e_ibt1:
+		ibt1(fd);
+		break;
+	case e_ibt2:
+		ibt_legal(fd);
+		break;
+	default:
+		break;
+	}
+
+	close(fd);
+
+	return 0;
+}

--- a/cet/cet_driver/cet_ioctl.c
+++ b/cet/cet_driver/cet_ioctl.c
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2022 Intel Corporation.
+
+/*
+ * cet_ioctl.c
+ *
+ * This file simulated stack changed by hack, CET should block hack func
+ *      - For cet hack simulation driver
+ */
+
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/version.h>
+#include <linux/fs.h>
+#include <linux/cdev.h>
+#include <linux/device.h>
+#include <linux/errno.h>
+#include <linux/uaccess.h>
+
+#include "cet_ioctl.h"
+
+#define FIRST_MINOR 0
+#define MINOR_CNT 1
+
+static dev_t dev;
+static struct cdev c_dev;
+static struct class *cl;
+
+static int my_open(struct inode *i, struct file *f)
+{
+	return 0;
+}
+
+static int my_close(struct inode *i, struct file *f)
+{
+	return 0;
+}
+
+void dump_buffer(unsigned char *buf, int size)
+{
+	int i, j;
+
+	pr_info("xsave size = %d (%03xh)\n", size, size);
+
+	for (i = 0; i < size; i += 16) {
+		pr_info("%04x: ", i);
+
+		for (j = i; ((j < i + 16) && (j < size)); j++)
+			pr_info("%02x ", buf[j]);
+		pr_info("\n");
+	}
+}
+
+void do_hack(void)
+{
+	pr_info("Access hack function\n");
+	pr_info("You see this line, which means kernel space shstk failed!\n");
+}
+
+void cet_shstk1(void)
+{
+	unsigned long *func_bp;
+
+	asm("movq %%rbp,%0" : "=r"(func_bp));
+	pr_info("access kernel space cet shstk function\n");
+	pr_info("[INFO]\tReal shstk function rbp content:%lx for main rbp.\n",
+		*func_bp);
+	*(func_bp + 1) = (unsigned long)do_hack;
+}
+
+void cet_ibt1(void)
+{
+	pr_info("ibt1:jmp back with *%%rax\n");
+
+	#ifdef __x86_64__
+		asm volatile ("leaq 1f, %rax;"
+			"jmp *%rax;"
+			"1:nop"
+		);
+	#else
+		asm volatile ("lea 1f, %eax;"
+			"jmp *%eax;"
+			"1:nop"
+		);
+	#endif
+}
+
+void cet_ibt_legal(void)
+{
+	pr_info("ibt with legal endbr64 flag:jmp back with *%%rax\n");
+
+	#ifdef __x86_64__
+		asm volatile ("leaq 1f, %rax;"
+			"jmp *%rax;"
+			"1:endbr64"
+		);
+	#else
+		asm volatile ("lea 1f, %eax;"
+			"jmp *%eax;"
+			"1:endbr32"
+		);
+	#endif
+}
+
+static inline void cet_xsaves(uint32_t xstate_size)
+{
+	u32 ecx = MSR_IA32_PL3_SSP;
+	u32 eax, ebx, edx;
+
+	asm("rdmsr" : "=a" (eax), "=b" (ebx), "=d" (edx) : "c" (ecx));
+	pr_info("rdmsr 0x6a7: eax:%x, ebx:%x, ecx:%x, edx:%x\n",
+		eax, ebx, ecx, edx);
+}
+
+static long my_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
+{
+	u32 xstate_size;
+
+	pr_info("cet ioctl in kernel space\n");
+	switch (cmd) {
+	case CET_SHSTK1:
+		cet_shstk1();
+		break;
+	case CET_SHSTK_XSAVES:
+		xstate_size = get_xstate_size();
+		cet_xsaves(xstate_size);
+		break;
+	case CET_IBT1:
+		cet_ibt1();
+		break;
+	case CET_IBT2:
+		cet_ibt_legal();
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static const struct file_operations query_fops = {
+	.owner = THIS_MODULE,
+	.open = my_open,
+	.release = my_close,
+	.unlocked_ioctl = my_ioctl
+};
+
+static int __init cet_ioctl_init(void)
+{
+	int ret;
+	struct device *dev_ret;
+
+	pr_info("Load cet_ioctl start\n");
+	ret = alloc_chrdev_region(&dev, FIRST_MINOR, MINOR_CNT, "cet_ioctl");
+	if (ret < 0)
+		return ret;
+
+	cdev_init(&c_dev, &query_fops);
+
+	ret = cdev_add(&c_dev, dev, MINOR_CNT);
+	if (ret < 0)
+		return ret;
+
+	cl = class_create(THIS_MODULE, "char");
+	if (IS_ERR(cl)) {
+		cdev_del(&c_dev);
+		unregister_chrdev_region(dev, MINOR_CNT);
+		return PTR_ERR(cl);
+	}
+
+	dev_ret = device_create(cl, NULL, dev, NULL, "cet");
+	if (IS_ERR(dev_ret)) {
+		class_destroy(cl);
+		cdev_del(&c_dev);
+		unregister_chrdev_region(dev, MINOR_CNT);
+		return PTR_ERR(dev_ret);
+	}
+
+	return 0;
+}
+
+static void __exit cet_ioctl_exit(void)
+{
+	pr_info("Unload cet_ioctl, bye.\n");
+	device_destroy(cl, dev);
+	class_destroy(cl);
+	cdev_del(&c_dev);
+	unregister_chrdev_region(dev, MINOR_CNT);
+}
+
+module_init(cet_ioctl_init);
+module_exit(cet_ioctl_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("XPF");
+MODULE_DESCRIPTION("cet ioctl() Driver");

--- a/cet/cet_driver/cet_ioctl.h
+++ b/cet/cet_driver/cet_ioctl.h
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/* Copyright (c) 2022 Intel Corporation. */
+
+/*
+ * cet_ioctl.h:
+ * This file is cet driver head
+ *      - cet driver head file
+ */
+
+#ifndef QUERY_IOCTL_H
+#define QUERY_IOCTL_H
+#include <linux/ioctl.h>
+
+#define CET_SHSTK1 _IO('q', 4)
+#define CET_IBT1 _IO('q', 5)
+#define CET_IBT2 _IO('q', 6)
+#define CET_SHSTK_XSAVES _IO('q', 7)
+
+#endif
+
+#ifndef __cpuid_count
+#define __cpuid_count(level, count, a, b, c, d) ({	\
+	__asm__ __volatile__ ("cpuid\n\t"	\
+			: "=a" (a), "=b" (b), "=c" (c), "=d" (d)	\
+			: "0" (level), "2" (count));	\
+})
+#endif
+
+#define CPUID_LEAF_XSTATE		0xd
+#define CPUID_SUBLEAF_XSTATE_USER	0x0
+
+#define MSR_IA32_PL3_SSP	0x000006a7 /* user shadow stack pointer */
+
+/* The following definition is from arch/x86/include/asm/fpu/types.h */
+#define XFEATURE_MASK_FP (1 << XFEATURE_FP)
+#define XFEATURE_MASK_SSE (1 << XFEATURE_SSE)
+#define XFEATURE_MASK_CET_USER		(1 << XFEATURE_CET_USER)
+
+#define XFEATURE_CET_USER 11
+
+static uint32_t get_xstate_size(void)
+{
+	uint32_t eax, ebx, ecx, edx;
+
+	__cpuid_count(CPUID_LEAF_XSTATE, CPUID_SUBLEAF_XSTATE_USER, eax, ebx,
+		      ecx, edx);
+	/*
+	 * EBX enumerates the size (in bytes) required by the XSAVE
+	 * instruction for an XSAVE area containing all the user state
+	 * components corresponding to bits currently set in XCR0.
+	 */
+	return ebx;
+}

--- a/cet/tests
+++ b/cet/tests
@@ -1,6 +1,7 @@
 # This file collects the CET(Control-flow Enforcement Technology) tests on
 # Intel® Architecture-based platforms.
 
+# User space SHSTK tests
 cet_tests.sh -t cp_test -n shstk_cp -k "control protection"
 quick_test
 shstk_alloc
@@ -8,3 +9,6 @@ shstk_huge_page
 shstk_unlock_test
 test_shadow_stack
 wrss
+# Kernel space IBT tests
+./cet_tests.sh -t kmod_ibt_illegal -n cet_app -p "b1" -k "Missing ENDBR"
+./cet_tests.sh -t kmod_ibt_legal -n cet_app -p "b2" -k "Missing ENDBR"


### PR DESCRIPTION
Add 2 kernel space IBT test cases:
It will load cet_driver/cet_ioctl.ko module for kernel space IBT tests.
1. "./cet_app b1" will execute illegal indirect jump IBT in kernel space and trigger "Missing ENDBR" BUG dmesg info and it means kernel IBT prevent the IBT violation as expected, and kernel space should not exist IBT violation and trigger "Missing ENDBR" issue, so kernel still reports this issue as BUG.
2. "./cet_app b2" will execute leagal indirect jump IBT in kernel space and should not trigger "Missing ENDBR" BUG dmesg info.

Signed-off-by: Pengfei Xu <pengfei.xu@intel.com>