### PR TITLE
cet: update the ARCH_SHSTK bits name to match with latest kernel code

### DIFF
--- a/cet/README.md
+++ b/cet/README.md
@@ -36,7 +36,7 @@ Test SHSTK violation by arch_prctl syscall way in non-SHSTK binary with below
 points:
 1. Enable shadow stack by ARCH_CET_ENABLE syscall
 2. Disable shadow stack by ARCH_CET_DISABLE syscall
-3. Enable SHSTK writeable by CET_WRSS syscall
+3. Enable SHSTK writeable by ARCH_SHSTK_WRSS syscall
 4. Allocate the shstk buffer by map_shadow_stack syscall
 5. Do the SHSTK violation by wrss the wrong shstk value, and recevie the
    expected signal SIGSEGV
@@ -61,7 +61,7 @@ This tool's purpose is testing SHSTK related instructions:
 ./wrss
 This tool will test wrss into shadow stack by wrss(q for 64bit) instruction in
 SHSTK enabled binary:
-1. Enable writable shadow stack via system call "ARCH_CET_ENABLE and CET_WRSS"
+1. Enable writable shadow stack via system call "ARCH_CET_ENABLE and ARCH_SHSTK_WRSS"
 2. Write one incorrect value into shadow stack
 3. The expected SISEGV should be received after ret instruction
 

--- a/cet/shstk_cp.c
+++ b/cet/shstk_cp.c
@@ -27,8 +27,9 @@
 #define ARCH_CET_ENABLE		0x5001
 #define ARCH_CET_DISABLE	0x5002
 #define ARCH_CET_UNLOCK		0x5004
-#define CET_SHSTK		(1ULL <<  0)
-#define CET_WRSS		(1ULL <<  1)
+/* ARCH_SHSTK_ features bits */
+#define ARCH_SHSTK_SHSTK		(1ULL <<  0)
+#define ARCH_SHSTK_WRSS			(1ULL <<  1)
 /* It's from arch/x86/entry/syscalls/syscall_64.tbl file. */
 #define __NR_map_shadow_stack	451
 
@@ -97,20 +98,20 @@ int main(void)
 	int ret = 0;
 	unsigned long ssp;
 
-	if (ARCH_PRCTL(ARCH_CET_ENABLE, CET_SHSTK)) {
+	if (ARCH_PRCTL(ARCH_CET_ENABLE, ARCH_SHSTK_SHSTK)) {
 		printf("[SKIP]\tCould not enable Shadow stack.\n");
 		return 1;
 	}
 	printf("[PASS]\tEnable SHSTK successfully\n");
 
-	if (ARCH_PRCTL(ARCH_CET_DISABLE, CET_SHSTK)) {
+	if (ARCH_PRCTL(ARCH_CET_DISABLE, ARCH_SHSTK_SHSTK)) {
 		ret = 1;
 		printf("[FAIL]\tDisabling shadow stack failed\n");
 	} else {
 		printf("[PASS]\tDisabling shadow stack successfully\n");
 	}
 
-	if (ARCH_PRCTL(ARCH_CET_ENABLE, CET_SHSTK)) {
+	if (ARCH_PRCTL(ARCH_CET_ENABLE, ARCH_SHSTK_SHSTK)) {
 		printf("[SKIP]\tCould not re-enable Shadow stack.\n");
 		return 1;
 	}

--- a/cet/shstk_unlock_test.c
+++ b/cet/shstk_unlock_test.c
@@ -36,8 +36,9 @@
 #define ARCH_SHSTK_LOCK		0x5003
 #define ARCH_SHSTK_UNLOCK	0x5004
 #define ARCH_SHSTK_STATUS	0x5005
-#define CET_SHSTK		(1ULL <<  0)
-#define CET_WRSS		(1ULL <<  1)
+/* ARCH_SHSTK_ features bits */
+#define ARCH_SHSTK_SHSTK		(1ULL <<  0)
+#define ARCH_SHSTK_WRSS			(1ULL <<  1)
 /* It's from arch/x86/entry/syscalls/syscall_64.tbl file. */
 #define __NR_map_shadow_stack	451
 /* It's from include/uapi/linux/elf.h. */
@@ -123,7 +124,7 @@ long unlock_shstk(pid_t pid)
 		goto detach;
 	}
 
-	if (ptrace(PTRACE_ARCH_PRCTL, pid, CET_SHSTK, ARCH_SHSTK_UNLOCK)) {
+	if (ptrace(PTRACE_ARCH_PRCTL, pid, ARCH_SHSTK_SHSTK, ARCH_SHSTK_UNLOCK)) {
 		printf("[FAIL]\tCan't unlock CET for %d task", pid);
 		result = 1;
 		goto detach;
@@ -201,7 +202,7 @@ int main(void)
 	unsigned long *ssp, *bp, i, loop_num = 1000000;
 	long ret = 0, result = 0;
 
-	if (ARCH_PRCTL(ARCH_SHSTK_ENABLE, CET_SHSTK)) {
+	if (ARCH_PRCTL(ARCH_SHSTK_ENABLE, ARCH_SHSTK_SHSTK)) {
 		printf("[FAIL]\tParent process could not enable SHSTK!\n");
 		return 1;
 	}
@@ -245,7 +246,7 @@ int main(void)
 		printf("[INFO]\tChild:%d, ssp:%p, bp,%p, *bp:%lx, *(bp+1):%lx\n",
 		       getpid(), ssp, bp, *bp, *(bp + 1));
 
-		if (ARCH_PRCTL(ARCH_SHSTK_DISABLE, CET_SHSTK)) {
+		if (ARCH_PRCTL(ARCH_SHSTK_DISABLE, ARCH_SHSTK_SHSTK)) {
 			printf("[FAIL]\tDisabling shadow stack failed\n");
 			result = 1;
 		} else {
@@ -266,7 +267,7 @@ int main(void)
 			result = 1;
 		}
 
-		if (ARCH_PRCTL(ARCH_SHSTK_ENABLE, CET_SHSTK)) {
+		if (ARCH_PRCTL(ARCH_SHSTK_ENABLE, ARCH_SHSTK_SHSTK)) {
 			printf("[FAIL]\tCould not re-enable Shadow stack.\n");
 			result = 1;
 		} else {
@@ -287,7 +288,7 @@ int main(void)
 			result = 1;
 		}
 
-		if (ARCH_PRCTL(ARCH_SHSTK_ENABLE, CET_WRSS)) {
+		if (ARCH_PRCTL(ARCH_SHSTK_ENABLE, ARCH_SHSTK_WRSS)) {
 			printf("[FAIL]\tCould not enable WRSS in child pid.\n");
 			result = 1;
 		} else {
@@ -322,7 +323,7 @@ int main(void)
 			result = 1;
 		}
 
-		if (ARCH_PRCTL(ARCH_SHSTK_DISABLE, CET_SHSTK)) {
+		if (ARCH_PRCTL(ARCH_SHSTK_DISABLE, ARCH_SHSTK_SHSTK)) {
 			printf("[FAIL]\tChild process could not disable shstk.\n");
 			result = 1;
 		} else {
@@ -354,7 +355,7 @@ int main(void)
 			}
 		}
 		/* Disable SHSTK in parent process to avoid segfault issue. */
-		if (ARCH_PRCTL(ARCH_SHSTK_DISABLE, CET_SHSTK)) {
+		if (ARCH_PRCTL(ARCH_SHSTK_DISABLE, ARCH_SHSTK_SHSTK)) {
 			printf("[FAIL]\tParent process disable shadow stack failed.\n");
 			result = 1;
 		} else {

--- a/cet/wrss.c
+++ b/cet/wrss.c
@@ -4,7 +4,7 @@
 /*
  * wrss.c: enable writable shadow stack and write value into shadow stack.
  *
- * 1. Enable writable shadow stack via syscall "ARCH_CET_ENABLE and CET_WRSS"
+ * 1. Enable writable shadow stack via syscall "ARCH_CET_ENABLE and ARCH_SHSTK_WRSS"
  * 2. Write one incorrect value into shadow stack
  * 3. The expected SISEGV should be received after ret instruction
  */
@@ -30,8 +30,9 @@
 /* It's from arch/x86/include/uapi/asm/prctl.h file. */
 #define ARCH_CET_ENABLE		0x5001
 #define ARCH_CET_DISABLE	0x5002
-#define CET_SHSTK		(1ULL <<  0)
-#define CET_WRSS		(1ULL <<  1)
+/* ARCH_SHSTK_ features bits */
+#define ARCH_SHSTK_SHSTK		(1ULL <<  0)
+#define ARCH_SHSTK_WRSS			(1ULL <<  1)
 /* It's from arch/x86/entry/syscalls/syscall_64.tbl file. */
 #define __NR_map_shadow_stack	451
 
@@ -131,9 +132,9 @@ static void *sigill_receive_expected(int signum, siginfo_t *info,
 
 	/*
 	 * arch_prctl libc has same result as ARCH_PRCTL(),
-	 * ret = syscall(SYS_arch_prctl, ARCH_CET_ENABLE, CET_WRSS);
+	 * ret = syscall(SYS_arch_prctl, ARCH_CET_ENABLE, ARCH_SHSTK_WRSS);
 	 */
-	if (ARCH_PRCTL(ARCH_CET_ENABLE, CET_WRSS)) {
+	if (ARCH_PRCTL(ARCH_CET_ENABLE, ARCH_SHSTK_WRSS)) {
 		printf("[SKIP]\tCould not enable WRSS.\n");
 		ret = 1;
 		exit(ret);
@@ -158,7 +159,7 @@ int main(int argc, char *argv[])
 {
 	unsigned long *current_shstk;
 
-	if (ARCH_PRCTL(ARCH_CET_ENABLE, CET_SHSTK)) {
+	if (ARCH_PRCTL(ARCH_CET_ENABLE, ARCH_SHSTK_SHSTK)) {
 		printf("[SKIP]\tCould not enable Shadow stack.\n");
 		return 1;
 	}


### PR DESCRIPTION
The ARCH_SHSTK related features bits number doesn't change, but the name changes in latest user space shstk kernel code, so update them to keep them same.
Related latest user space shstk code patches link: https://lore.kernel.org/lkml/20230218211433.26859-35-rick.p.edgecombe@intel.com/