### PR TITLE
cet: improve __NR_map_shadow_stack definition to avoid the warning

### DIFF
--- a/cet/shstk_alloc.c
+++ b/cet/shstk_alloc.c
@@ -24,7 +24,9 @@
 #include <x86intrin.h>
 
 #define SHADOW_STACK_SET_TOKEN	0x1
+#ifndef __NR_map_shadow_stack
 #define __NR_map_shadow_stack 451
+#endif
 
 size_t shstk_size = 0x200000;
 

--- a/cet/shstk_cp.c
+++ b/cet/shstk_cp.c
@@ -31,7 +31,9 @@
 #define ARCH_SHSTK_SHSTK		(1ULL <<  0)
 #define ARCH_SHSTK_WRSS			(1ULL <<  1)
 /* It's from arch/x86/entry/syscalls/syscall_64.tbl file. */
-#define __NR_map_shadow_stack	451
+#ifndef __NR_map_shadow_stack
+#define __NR_map_shadow_stack 451
+#endif
 
 #define rdssp() ({						\
 	unsigned long _ret;					\

--- a/cet/shstk_huge_page.c
+++ b/cet/shstk_huge_page.c
@@ -19,7 +19,9 @@
 /* It's from arch/x86/include/uapi/asm/mman.h file. */
 #define SHADOW_STACK_SET_TOKEN	0x1
 /* It's from arch/x86/entry/syscalls/syscall_64.tbl file. */
-#define __NR_map_shadow_stack	451
+#ifndef __NR_map_shadow_stack
+#define __NR_map_shadow_stack 451
+#endif
 
 #define PASS		0
 #define FAIL		1

--- a/cet/shstk_unlock_test.c
+++ b/cet/shstk_unlock_test.c
@@ -40,7 +40,9 @@
 #define ARCH_SHSTK_SHSTK		(1ULL <<  0)
 #define ARCH_SHSTK_WRSS			(1ULL <<  1)
 /* It's from arch/x86/entry/syscalls/syscall_64.tbl file. */
-#define __NR_map_shadow_stack	451
+#ifndef __NR_map_shadow_stack
+#define __NR_map_shadow_stack 451
+#endif
 /* It's from include/uapi/linux/elf.h. */
 #define NT_X86_SHSTK		0x204
 #define NT_X86_XSTATE		0x202

--- a/cet/test_shadow_stack.c
+++ b/cet/test_shadow_stack.c
@@ -50,7 +50,9 @@
 #define ARCH_SHSTK_SHSTK		(1ULL <<  0)
 #define ARCH_SHSTK_WRSS			(1ULL <<  1)
 /* It's from arch/x86/entry/syscalls/syscall_64.tbl file. */
-#define __NR_map_shadow_stack	451
+#ifndef __NR_map_shadow_stack
+#define __NR_map_shadow_stack 451
+#endif
 
 #if (__GNUC__ < 8) || (__GNUC__ == 8 && __GNUC_MINOR__ < 5)
 int main(int argc, char *argv[])

--- a/cet/wrss.c
+++ b/cet/wrss.c
@@ -34,7 +34,9 @@
 #define ARCH_SHSTK_SHSTK		(1ULL <<  0)
 #define ARCH_SHSTK_WRSS			(1ULL <<  1)
 /* It's from arch/x86/entry/syscalls/syscall_64.tbl file. */
-#define __NR_map_shadow_stack	451
+#ifndef __NR_map_shadow_stack
+#define __NR_map_shadow_stack 451
+#endif
 
 /* err() exits and will not return */
 #define fatal_error(msg, ...)	err(1, "[FAIL]\t" msg, ##__VA_ARGS__)


### PR DESCRIPTION
When compile in cet user space SHSTK kernel, /usr/include/asm/unistd.h or /usr/include/sys/syscall.h or /usr/include/asm/unistd_64.h will define __NR_map_shadow_stack syscall number, and will trigger below WARNING: "
warning: "__NR_map_shadow_stack" redefined
"#define __NR_map_shadow_stack 451"
"
Improve the __NR_map_shadow_stack definition to avoid the warning.