### PR TITLE
Dockerfile: Use native kernel headers when building Kernel module

### DIFF
--- a/.github/scripts/build_check
+++ b/.github/scripts/build_check
@@ -6,7 +6,7 @@ set -oe pipefail
 wpattern=" warning: "
 logfile="build.log"
 
-docker run -v "$(pwd)":/src builder make | tee "$logfile"
+docker run -v "$(pwd)":/src builder make test | tee "$logfile"
 
 if grep "$wpattern" "$logfile"; then
   echo "==========================================="

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -7,15 +7,18 @@ ARG PROXY
 ENV http_proxy=$PROXY
 ENV https_proxy=$PROXY
 
-COPY common/uname /usr/local/sbin/
+COPY common/uname /usr/local/
 
 RUN dpkg --add-architecture i386
 RUN dpkg --print-foreign-architectures
 RUN \
 	apt-get update && \
-	apt-get install gcc-11 make libelf1 gcc-multilib g++-multilib git cmake linux-headers-`uname -r` -y --no-install-recommends && \
+	apt-get install gcc-11 make libelf1 gcc-multilib g++-multilib git cmake -y --no-install-recommends && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*
+
+#RUN apt-get install linux-headers-`uname -r` -y
+RUN apt-get update && apt-get install linux-headers-5.15.0-52-generic -y
 
 RUN export GIT_SSL_NO_VERIFY=true && rm -rf libipt && git clone http://github.com/intel/libipt.git && \
 	cd libipt && cmake . && make install

--- a/Makefile
+++ b/Makefile
@@ -10,23 +10,31 @@ all:
 			cd .. || exit 2;		\
 		fi					\
 	done
-
 clean:
 	for dir in $(SUBDIRS) ; do 			\
 		if [ -f "$$dir/Makefile" ]; then	\
 			make -C  $$dir clean || exit 2;	\
 		fi					\
 	done
+docker_clean:
+	docker run -it --rm -v $(PWD):/src --name ubuntu_2204_lkvs ubuntu:22.04 make clean
+
+# Target test and docker_test are for github action mainly.
+# It's used to do a compiling validation.
+# User should not use this becasue it will be produced the
+# module with kernel 5.15 very old one.
+test:
+	@cp /usr/local/uname /usr/local/sbin/
+	$(MAKE) all
+	@rm /usr/local/sbin/uname
+docker_test:
+	docker run -it --rm -v $(PWD):/src --name ubuntu_2204_lkvs ubuntu:22.04 make test
 
 docker_image:
 	docker build --build-arg PROXY=$(https_proxy) -f ./Dockerfile.build -t ubuntu:22.04 .
 
 docker_make:
-	docker run -it --rm -v $(PWD):/src --name ubuntu_2204_lkvs ubuntu:22.04 make
-
-docker_clean:
-	docker run -it --rm -v $(PWD):/src --name ubuntu_2204_lkvs ubuntu:22.04 make clean
-
+	docker run -it --rm -v $(PWD):/src -v /lib/modules/`uname -r`:/lib/modules/`uname -r` --name ubuntu_2204_lkvs ubuntu:22.04 make
 
 build:
 	@echo "Building $(word 2, $(MAKECMDGOALS))"
@@ -36,5 +44,17 @@ build:
 docker-build:
 	@echo "Building $* in docker!"
 	docker run -it --rm -v $(PWD):/src --name ubuntu_2204_lkvs ubuntu:22.04 bash -c "make build $(word 2, $(MAKECMDGOALS))"
+
+# Targets build-test and docker-build-test are for test purpose.
+# It's used to do a compiling validation.
+# User should not use this becasue it will be produced the
+# module with kernel 5.15 very old one.
+build-test:
+	@cp /usr/local/uname /usr/local/sbin/
+	@cd $(word 2, $(MAKECMDGOALS)) && make
+	@cd ..
+	@rm /usr/local/sbin/uname
+docker-build-test:
+	docker run -it --rm -v $(PWD):/src --name ubuntu_2204_lkvs ubuntu:22.04 bash -c "make build-test $(word 2, $(MAKECMDGOALS))"
 
 .PHONY: build docker-build


### PR DESCRIPTION
Pass the local /lib/modules folder to the docker for kernel cases compiling.