### PR TITLE
Fixup: ubuntu22.04 image no longer support kernel-header-5.15

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -18,7 +18,7 @@ RUN \
 	rm -rf /var/lib/apt/lists/*
 
 #RUN apt-get install linux-headers-`uname -r` -y
-RUN apt-get update && apt-get install linux-headers-5.15.0-52-generic -y
+RUN apt-get update && apt-get install linux-headers-generic linux-headers-5.19.0-41-generic -y
 
 RUN export GIT_SSL_NO_VERIFY=true && rm -rf libipt && git clone http://github.com/intel/libipt.git && \
 	cd libipt && cmake . && make install

--- a/common/uname
+++ b/common/uname
@@ -7,10 +7,10 @@
 while getopts ":armpios" arg; do
   case $arg in
     a)
-      echo "Linux lkvs 5.15.0-52-generic #58-Ubuntu SMP Thu Oct 13 08:03:55 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux"
+      echo "Linux lkvs 5.19.0-41-generic #58-Ubuntu SMP Thu Oct 13 08:03:55 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux"
       ;;
     r)
-      echo "5.15.0-52-generic"
+      echo "5.19.0-41-generic"
       ;;
     m|p|i)
       echo "x86_64"


### PR DESCRIPTION
Install linux-headers-5.19.0-41-generic instead.