### PR TITLE
cet/shstk_alloc.c: unable to show content of switched ssp content due…

### DIFF
--- a/cet/shstk_alloc.c
+++ b/cet/shstk_alloc.c
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: GPL-2.0-only
-// Copyright (c) 2022 Intel Corporation.
-
 // SPDX-License-Identifier: GPL-2.0
 /*
  * shstk_alloc.c - allocate a new shadow stack buffer aligenment by instructions
@@ -109,7 +106,7 @@ void try_shstk(unsigned long new_ssp)
 	asm volatile("rstorssp (%0)\n":: "r" (new_ssp));
 	asm volatile("saveprevssp");
 	ssp1 = get_ssp();
-	printf("ssp is now %lx, *ssp:%lx\n", ssp1, *((unsigned long *)ssp1));
+	printf("ssp is now %lx\n", ssp1);
 
 	ssp0 -= 8;
 	asm volatile("rstorssp (%0)\n":: "r" (ssp0));
@@ -146,9 +143,9 @@ int main(int argc, char *argv[])
 	if (ARCH_PRCTL(ARCH_SHSTK_DISABLE, ARCH_SHSTK_SHSTK)) {
 		printf("[FAIL]\tParent process disable shadow stack failed.\n");
 		return 1;
-	} else {
-		printf("[PASS]\tParent process disable shadow stack successfully.\n");
 	}
+	printf("[PASS]\tParent process disable shadow stack successfully.\n");
+
 	return 0;
 }
 #endif


### PR DESCRIPTION
… to kernel protection

Since the v6.5 cycle latest cet userspace shstk patch improvements, switched ssp content will be protected and it makes sense, if code wants to show the switched ssp content, it will get fake segfault like this: "
ssp0 & (-8): 7f5d4efffff8
Segmentation fault (core dumped)
"
Dmesg shows the segfault as following:
"
shstk_alloc[3080]: segfault at 7f5d4e7ff000 ip 0000000000401258 sp 00007ffcd214f180 error 4 in shstk_alloc[401000+1000] likely on CPU 15 (core 3, socket 0) "
So code should not show worked and switched ssp content to avoid fake failure.