### PR TITLE
cet: change objdump output file location

### DIFF
--- a/cet/cet_tests.sh
+++ b/cet/cet_tests.sh
@@ -64,7 +64,7 @@ cet_shstk_check() {
   local ssp=""
   local bp_add=""
   local sp=""
-  local obj_log="/tmp/${bin_name}.txt"
+  local obj_log="${bin_name}.txt"
 
   bin=$(which "$bin_name")
   if [[ -e "$bin" ]]; then


### PR DESCRIPTION
$1 is parsed as full path "/home/lijun/lkvs/cet/glibc_shstk_test" instead of the intended "glibc_shstk_test". So save it at "/home/lijun/lkvs/cet/glibc_shstk_test.txt" instead of "/tmp/glibc_shstk_test.txt"

Logs:
<<<test start - 'cet_tests.sh -t cet_ssp -n glibc_shstk_test -p ssp'>> |0822_170810.092|TRACE|Test bin:/home/lijun/lkvs/cet/glibc_shstk_test ssp, cet_ssp:check dmesg | |0822_170810.099|TRACE|Find bin:/home/lijun/lkvs/cet/glibc_shstk_test| |0822_170810.149|TRACE|recorded dmesg timestamp: 20899.763861| |0822_170810.159|TRACE|/home/lijun/lkvs/cet/glibc_shstk_test ssp| |0822_170811.275|TRACE|do_cmd() is called by cet_tests.sh:91:cet_shstk_check()| |0822_170811.279|TRACE|CMD=objdump -d /home/lijun/lkvs/cet/glibc_shstk_test > /tmp//home/lijun/lkvs/cet/glibc_shstk_test.txt| /home/lijun/lkvs/common/common.sh: line 94: /tmp//home/lijun/lkvs/cet/glibc_shstk_test.txt: No such file or directory |0822_170811.285|ERROR| common.sh:98:do_cmd() - objdump -d /home/lijun/lkvs/cet/glibc_shstk_test > /tmp//home/lijun/lkvs/cet/glibc_shstk_test.txt failed. Return code is 1|

After applying the change:
<<<test start - 'cet_tests.sh -t cet_ssp -n glibc_shstk_test -p ssp'>> |0823_111212.048|TRACE|Test bin:/home/lijun/lkvs/cet/glibc_shstk_test ssp, cet_ssp:check dmesg | |0823_111212.051|TRACE|Find bin:/home/lijun/lkvs/cet/glibc_shstk_test| |0823_111212.077|TRACE|recorded dmesg timestamp: 85940.793241| |0823_111212.081|TRACE|/home/lijun/lkvs/cet/glibc_shstk_test ssp| |0823_111213.134|TRACE|do_cmd() is called by cet_tests.sh:92:cet_shstk_check()| |0823_111213.136|TRACE|CMD=objdump -d /home/lijun/lkvs/cet/glibc_shstk_test > /home/lijun/lkvs/cet/glibc_shstk_test.txt| |0823_111213.154|TRACE|sp:401baf is same as ssp:401baf(size:8), pass| |0823_111213.155|TRACE|bp+1:401baf(size:8) is same as ssp:401baf(size:8), pass| |0823_111213.157|TRACE|-------- Teardown starts --------| |0823_111213.159|TRACE|Teardown handler: cet_teardown| |0823_111213.166|TRACE|-------- Teardown ends ---------|
<<<test end, result: PASS, duration: 1.141>>