### PR TITLE
cet: update map_shadow_stack syscall number due to kernel code update

### DIFF
--- a/cet/shstk_alloc.c
+++ b/cet/shstk_alloc.c
@@ -33,7 +33,7 @@
 
 #define SHADOW_STACK_SET_TOKEN	0x1
 #ifndef __NR_map_shadow_stack
-#define __NR_map_shadow_stack 451
+#define __NR_map_shadow_stack 453
 #endif
 
 size_t shstk_size = 0x200000;

--- a/cet/shstk_cp.c
+++ b/cet/shstk_cp.c
@@ -30,10 +30,6 @@
 /* ARCH_SHSTK_ features bits */
 #define ARCH_SHSTK_SHSTK		(1ULL <<  0)
 #define ARCH_SHSTK_WRSS			(1ULL <<  1)
-/* It's from arch/x86/entry/syscalls/syscall_64.tbl file. */
-#ifndef __NR_map_shadow_stack
-#define __NR_map_shadow_stack 451
-#endif
 
 #define rdssp() ({						\
 	unsigned long _ret;					\

--- a/cet/shstk_huge_page.c
+++ b/cet/shstk_huge_page.c
@@ -20,7 +20,7 @@
 #define SHADOW_STACK_SET_TOKEN	0x1
 /* It's from arch/x86/entry/syscalls/syscall_64.tbl file. */
 #ifndef __NR_map_shadow_stack
-#define __NR_map_shadow_stack 451
+#define __NR_map_shadow_stack 453
 #endif
 
 #define PASS		0

--- a/cet/shstk_unlock_test.c
+++ b/cet/shstk_unlock_test.c
@@ -39,10 +39,7 @@
 /* ARCH_SHSTK_ features bits */
 #define ARCH_SHSTK_SHSTK		(1ULL <<  0)
 #define ARCH_SHSTK_WRSS			(1ULL <<  1)
-/* It's from arch/x86/entry/syscalls/syscall_64.tbl file. */
-#ifndef __NR_map_shadow_stack
-#define __NR_map_shadow_stack 451
-#endif
+
 /* It's from include/uapi/linux/elf.h. */
 #define NT_X86_SHSTK		0x204
 #define NT_X86_XSTATE		0x202

--- a/cet/wrss.c
+++ b/cet/wrss.c
@@ -35,7 +35,7 @@
 #define ARCH_SHSTK_WRSS			(1ULL <<  1)
 /* It's from arch/x86/entry/syscalls/syscall_64.tbl file. */
 #ifndef __NR_map_shadow_stack
-#define __NR_map_shadow_stack 451
+#define __NR_map_shadow_stack 453
 #endif
 
 /* err() exits and will not return */


### PR DESCRIPTION
User space SHSTK has been merged into Linux kernel main line: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=df57721f9a63e8a1fb9b9b2e70de4aa4c7e0cd2e

SHSTK syscall map_shadow_stack number is 453(not 451 or 452) in Linux mainline kernel:
https://github.com/torvalds/linux/blob/0468be89b3fa5b9249cee1097f1d50314950a2df/arch/x86/entry/syscalls/syscall_64.tbl#L377 All test kernel will follow the main line kernel, so update map_shadow_stack to 453 for future kernel tests.