### PR TITLE
Refine format of result lines

### DIFF
--- a/common/kselftest.h
+++ b/common/kselftest.h
@@ -152,10 +152,11 @@ static inline void ksft_test_result_pass(const char *msg, ...)
 	ksft_cnt.ksft_pass++;
 
 	va_start(args, msg);
-	printf("ok %d ", ksft_test_num());
+	printf("%d: ", ksft_test_num());
 	errno = saved_errno;
 	vprintf(msg, args);
 	va_end(args);
+	printf(": [PASS]\n");
 }
 
 static inline void ksft_test_result_fail(const char *msg, ...)
@@ -166,10 +167,11 @@ static inline void ksft_test_result_fail(const char *msg, ...)
 	ksft_cnt.ksft_fail++;
 
 	va_start(args, msg);
-	printf("not ok %d ", ksft_test_num());
+	printf("%d: ", ksft_test_num());
 	errno = saved_errno;
 	vprintf(msg, args);
 	va_end(args);
+	printf(": [FAIL]\n");
 }
 
 /**

--- a/xsave/xstate.c
+++ b/xsave/xstate.c
@@ -98,9 +98,9 @@ static void compare_buf_result(struct xsave_buffer *valid_buf,
 			       const char *case_name)
 {
 	if (memcmp(&valid_buf->bytes[0], &compare_buf->bytes[0], xstate_size))
-		ksft_test_result_fail("The case: %s.\n", case_name);
+		ksft_test_result_fail("%s", case_name);
 	else
-		ksft_test_result_pass("The case: %s.\n", case_name);
+		ksft_test_result_pass("%s", case_name);
 }
 
 static void test_xstate_sig_handle(void)
@@ -132,9 +132,9 @@ static void test_xstate_fork(void)
 	/* Child process xstate should be same as the parent process xstate. */
 	if (xstate_fork(valid_xbuf, compared_xbuf, xstate_info.mask,
 	    xstate_size)) {
-		ksft_test_result_pass("The case: %s.\n", case_name2);
+		ksft_test_result_pass("%s", case_name2);
 	} else {
-		ksft_test_result_fail("The case: %s.\n", case_name2);
+		ksft_test_result_fail("%s", case_name2);
 	}
 
 	/* The parent process xstate should not change after context switch. */


### PR DESCRIPTION
Refine the print of the result lines. And take xsave as a pilot case.