### PR TITLE
cpu topology: fix numa_nodes format

### DIFF
--- a/topology/cpu_topology.sh
+++ b/topology/cpu_topology.sh
@@ -48,10 +48,10 @@ numa_nodes_compare_with_package() {
   [[ -n $cpuinfo_nodes ]] || block_test "NUMA nodes info is not available from lscpu."
   test_print_trc "SUT NUMA nodes info from lscpu shows: $cpuinfo_nodes"
 
-  numa_nodes=$(grep . /sys/devices/system/node/node*/cpulist 2>&1)
+  numa_nodes=$(grep -H . /sys/devices/system/node/node*/cpulist 2>&1)
   [[ -n $numa_nodes ]] || block_test "NUMA nodes sysfs files is not available."
   test_print_trc "SUT NUMA nodes sysfs info: $numa_nodes"
-  nodes_lines=$(grep . /sys/devices/system/node/node*/cpulist | wc -l 2>&1)
+  nodes_lines=$(grep -H . /sys/devices/system/node/node*/cpulist | wc -l 2>&1)
 
   if [[ $socket_num -eq $nodes_lines ]]; then
     test_print_trc "SNC is disabled:"


### PR DESCRIPTION
The grep command may give different format of output when the system has one node or multiple nodes.

one node system:

  $ grep . /sys/devices/system/node/node*/cpulist
  0-35

two nodes system:

  $ grep . /sys/devices/system/node/node*/cpulist
  /sys/devices/system/node/node0/cpulist:0-25,52-77
  /sys/devices/system/node/node1/cpulist:26-51,78-103

If the system has only one node, subsequent code cannot parse noma_nodes correctly, causing wrong test result. Add -H option for grep command to unify the output format no matter how many nodes the system has.

== before fix ==

$ numa_nodes=$(grep . /sys/devices/system/node/node*/cpulist 2>&1) $ echo "$numa_nodes"
0-35
$ node_cpu_list=$(echo "$numa_nodes" | sed -n "1, 1p" | awk -F ":" '{print $2}') $ echo "$node_cpu_list"
<-- nothing

== after fix ==

$ numa_nodes=$(grep -H . /sys/devices/system/node/node*/cpulist 2>&1) $ echo "$numa_nodes"
/sys/devices/system/node/node0/cpulist:0-35
$ node_cpu_list=$(echo "$numa_nodes" | sed -n "1, 1p" | awk -F ":" '{print $2}') $ echo "$node_cpu_list"
0-35

Reported-by: kernel test robot <lkp@intel.com>