### PR TITLE
[tdx-guest] Test Enhance: compile based on kernel header define

### DIFF
--- a/tdx-guest/tdx_attest_test_suite/Makefile
+++ b/tdx-guest/tdx_attest_test_suite/Makefile
@@ -15,6 +15,45 @@ SOURCES := \
 
 MAKE_TARGETS            := tdx_guest_test
 
+SRC_INC := /usr/include/linux/tdx-guest.h
+
+# Check if TDX_CMD_GET_REPORT0 is defined in tdx-guest.h
+VERIFY_REPORT_DEFINED := $(shell grep -c "TDX_CMD_GET_REPORT0" $(SRC_INC))
+
+# Check if TDX_CMD_VERIFY_REPORT is defined in the source code
+VERIFY_REPORTMAC_DEFINED := $(shell grep -c "TDX_CMD_VERIFY_REPORT" $(SRC_INC))
+
+# Check if TDX_CMD_EXTEND_RTMR is defined in the source code
+VERIFY_RTMR_EXTEND_DEFINED := $(shell grep -c "TDX_CMD_EXTEND_RTMR" $(SRC_INC))
+
+# Check if TDX_CMD_GET_QUOTE is defined in the source code
+VERIFY_QUOTE_DEFINED := $(shell grep -c "TDX_CMD_GET_QUOTE" $(SRC_INC))
+
+
+# Conditional compilation based on whether TDX_CMD_GET_REPORT0 is defined
+ifneq ($(VERIFY_REPORT_DEFINED),0)
+    # enable compile macro in case of TDX_CMD_GET_REPORT0 is defined
+    CFLAGS += -DVERIFY_REPORT
+endif
+
+# Conditional compilation based on whether TDX_CMD_VERIFY_REPORT is defined
+ifneq ($(VERIFY_REPORTMAC_DEFINED),0)
+    # enable compile macro in case of TDX_CMD_VERIFY_REPORT is defined
+    CFLAGS += -DVERIFY_REPORTMAC
+endif
+
+# Conditional compilation based on whether TDX_CMD_EXTEND_RTMR is defined
+ifneq ($(VERIFY_RTMR_EXTEND_DEFINED),0)
+    # enable compile macro in case of TDX_CMD_EXTEND_RTMR is defined
+    CFLAGS += -DVERIFY_RTMR_EXTEND
+endif
+
+# Conditional compilation based on whether TDX_CMD_GET_QUOTE is defined
+ifneq ($(VERIFY_QUOTE_DEFINED),0)
+    # enable compile macro in case of TDX_CMD_GET_QUOTE is defined
+    CFLAGS += -DVERIFY_QUOTE
+endif
+
 tdx_guest_test:
 	$(CC) $(CFLAGS) $(LDFLAGS) -o ${MAKE_TARGETS} ${INCLUDES} ${SOURCES}
 

--- a/tdx-guest/tdx_attest_test_suite/tdx-attest-test.c
+++ b/tdx-guest/tdx_attest_test_suite/tdx-attest-test.c
@@ -157,6 +157,7 @@ long get_tdreport0(int devfd, struct tdx_report_req *req)
 	return ioctl(devfd, TDX_CMD_GET_REPORT0, req);
 }
 
+#ifdef VERIFY_REPORT
 TEST(verify_report)
 {
 	struct tdx_report_req req;
@@ -184,7 +185,9 @@ TEST(verify_report)
 
 	ASSERT_EQ(0, close(devfd));
 }
+#endif
 
+#ifdef VERIFY_REPORTMAC
 TEST(verify_reportmac)
 {
 	struct tdx_verify_report_req req = { };
@@ -212,7 +215,9 @@ TEST(verify_reportmac)
 
 	ASSERT_EQ(0, close(devfd));
 }
+#endif
 
+#ifdef VERIFY_RTMR_EXTEND
 TEST(verify_rtmr_extend)
 {
 	struct tdx_extend_rtmr_req req;
@@ -233,7 +238,9 @@ TEST(verify_rtmr_extend)
 
 	ASSERT_EQ(0, close(devfd));
 }
+#endif
 
+#ifdef VERIFY_QUOTE
 TEST(verify_quote)
 {
 	struct tdx_quote_hdr *quote_hdr;
@@ -280,5 +287,6 @@ TEST(verify_quote)
 
 	ASSERT_EQ(0, close(devfd));
 }
+#endif
 
 TEST_HARNESS_MAIN


### PR DESCRIPTION
compile test source code based on kernel header tdx-guest.h define to adapt to difference version of tdx guest kernel under test

[Test Components] tdx
[Test Types] func
[Supported Devices] spr,emr,gnr,srf