### PR TITLE
Update dependency for cstate/pstate/topology/thermal

### DIFF
--- a/cstate/tests-client
+++ b/cstate/tests-client
@@ -1,5 +1,8 @@
 # This file collects the CPU Core cstate cases which can run
 # on Intel® Architecture-based client platforms.
+# @hw_dep:
+# @other_dep:
+# @other_warn:
 
 powermgr_cstate_tests.sh -t verify_cstate_name
 powermgr_cstate_tests.sh -t verify_cstate_switch

--- a/cstate/tests-server
+++ b/cstate/tests-server
@@ -1,5 +1,8 @@
 # This file collects the CPU Core cstate cases which can run
 # on Intel® Architecture-based server platforms.
+# @hw_dep:
+# @other_dep:
+# @other_warn:
 
 powermgr_cstate_tests.sh -t verify_cstate_name
 powermgr_cstate_tests.sh -t verify_server_all_cores_cstate6

--- a/pstate/tests
+++ b/pstate/tests
@@ -3,6 +3,9 @@
 # scaling drivers on Intel® Architecture-based platforms
 # For a deeper understanding of HW P-state related MSRs,
 # Users may refer to the Intel® Software Developer Manual.
+# @hw_dep:
+# @other_dep:
+# @other_warn:
 
 intel_pstate_tests.sh -t verify_sysfs_atts
 intel_pstate_tests.sh -t verify_turbo_enable_disable

--- a/thermal/thermal-tests
+++ b/thermal/thermal-tests
@@ -1,5 +1,8 @@
 # This file collects thermal throttling and interrupts for x86_pkg_temp
 # thermal zone which is supported on Intel® Architecture-based platforms.
+# @hw_dep:
+# @other_dep:
+# @other_warn:
 
 thermal_test.sh -t check_thermal_throttling
 thermal_test.sh -t check_pkg_interrupts

--- a/topology/tests-client
+++ b/topology/tests-client
@@ -1,5 +1,8 @@
 # This file collects basic cases which verify CPU Topology
 # on Intel® Architecture-based client platforms.
+# @hw_dep:
+# @other_dep:
+# @other_warn:
 
 cpu_topology.sh -t verify_thread_per_core
 cpu_topology.sh -t verify_cores_per_socket

--- a/topology/tests-server
+++ b/topology/tests-server
@@ -1,5 +1,8 @@
 # This file collects basic cases which verify CPU Topology
 # on Intel® Architecture-based server platforms.
+# @hw_dep:
+# @other_dep:
+# @other_warn:
 
 cpu_topology.sh -t numa_nodes_compare
 cpu_topology.sh -t verify_thread_per_core


### PR DESCRIPTION
cstate/pstate/topology/thermal are legacy features Which do not need depend`ency check