### PR TITLE
Action: Ignore the shell rule 1090

### DIFF
--- a/.github/scripts/pr_check
+++ b/.github/scripts/pr_check
@@ -42,7 +42,7 @@ class CheckResult:
 
 
 class BashChecker:
-    EXCLUDE_CODES = [1091, 2010, 2011, 2012, 2013, 2086, 2126, 2206]
+    EXCLUDE_CODES = [1090, 1091, 2010, 2011, 2012, 2013, 2086, 2126, 2206]
 
     def __init__(self, df: DiffFile):
         self._diff_file = df


### PR DESCRIPTION
Can't follow non-constant source. Use a directive to specify location.

From the shellcheck document 1090:
ShellCheck is not able to include sourced files from paths that are determined at runtime. The file will not be read, potentially resulting in warnings about unassigned variables and similar.

It more likes the limitation of shellcheck, but not the source code, disable it.