### PR TITLE
general_test: add the module existence/load check function

### DIFF
--- a/BM/common/common.sh
+++ b/BM/common/common.sh
@@ -653,3 +653,25 @@ check_turbostat_ver() {
 2024 version from the latest upstream kernel source located at: tools/power/x86/turbostat"
   fi
 }
+
+# Check module existence. If not, try to load module
+# Arguments: $1 module name
+# Output: 0 for module exists or loaded succss; 1 for module loaded failure
+check_module() {
+  local module_name=$1
+
+  module_exist=$(lsmod | grep -w "$module_name")
+  if [[ -n "$module_exist" ]]; then
+    test_print_trc "Module $module_name is already loaded"
+  else
+    modprobe $module_name
+    if [ $? -eq 0 ]; then
+      test_print_trc "Module $module_name is loaded"
+    else
+      block_test "Module $module_name cannot be loaded"
+      return 1
+    fi
+  fi
+
+  return 0
+}

--- a/BM/common/general_test.sh
+++ b/BM/common/general_test.sh
@@ -11,9 +11,12 @@ cd "$(dirname "$0")" 2>/dev/null && source ../.env
 usage() {
   cat <<__EOF
   usage: ./${0##*/} [-t TEST_TYPE][-k KCONFIG or keywrod][-p parm][-h]
-  -t  Test type like KCONFIG, FMS
+  -t  Test type, i.e., kconfig | fms | dmesg | turbostat | module
   -k  KCONFIG name like CONFIG_XXX or keyword
-  -p  PARM like y, null
+  -p  PARM for test
+        option for dmesg check
+        fms list file for fms check
+        module name for module check
   -h  show This
 __EOF
 }
@@ -38,6 +41,9 @@ general_test() {
     ;;
   turbostat)
     check_turbostat_ver
+    ;;
+  module)
+    check_module "$PARM"
     ;;
   *)
     die "Invalid TYPE:$TYPE"


### PR DESCRIPTION
check_module function can be used to check whether a module exists or can be loaded.
Example usage:
./general_test.sh -t module -p einj
Example output:
|0715_165104.347|TRACE|Module einj is already loaded|