### PR TITLE
Add turbo freq case with all the cstate default state

### DIFF
--- a/BM/cstate/powermgr_cstate_tests.sh
+++ b/BM/cstate/powermgr_cstate_tests.sh
@@ -950,6 +950,9 @@ core_cstate_test() {
   verify_ccstate_res_offline_online)
     ccstate_res_offline_online 0x10 0x660 0x3fd
     ;;
+  verify_turbo_freq_in_default)
+    verify_single_cpu_freq
+    ;;
   verify_turbo_freq_in_poll)
     turbo_freq_when_idle POLL
     ;;

--- a/BM/cstate/tests-server
+++ b/BM/cstate/tests-server
@@ -11,7 +11,6 @@ powermgr_cstate_tests.sh -t verify_cstate_name
 powermgr_cstate_tests.sh -t verify_server_all_cores_cstate6
 powermgr_cstate_tests.sh -t verify_server_all_cpus_mc6
 powermgr_cstate_tests.sh -t verify_server_core_cstate6_residency
-powermgr_cstate_tests.sh -t verify_residency_latency_override
 powermgr_cstate_tests.sh -t verify_server_cstate_list
 powermgr_cstate_tests.sh -t verify_server_perf_core_cstat_update
 powermgr_cstate_tests.sh -t verify_server_perf_pkg_cstat_update
@@ -25,6 +24,7 @@ powermgr_cstate_tests.sh -t verify_offline_cpu_deepest_pc
 powermgr_cstate_tests.sh -t verify_ccstate_res_offline_online
 # Below case are to verify whether a single CPU can reach the turbo frequecy
 # When other CPUs are all in POLL or C1 or C1E
+powermgr_cstate_tests.sh -t verify_turbo_freq_in_default
 powermgr_cstate_tests.sh -t verify_turbo_freq_in_poll
 powermgr_cstate_tests.sh -t verify_turbo_freq_in_c1
 powermgr_cstate_tests.sh -t verify_turbo_freq_in_c1e


### PR DESCRIPTION
Add turbo freq case with all the cstate default state Remove residency latency override case as mainline kernel does not support