### PR TITLE
[lkvs] [guest-test] Bug Fix: update -no-hpet to -machine q35,hpet=off

### DIFF
--- a/BM/guest-test/qemu.config.json
+++ b/BM/guest-test/qemu.config.json
@@ -12,7 +12,7 @@
   "vm": {
     "cfg_1": "-accel kvm -no-reboot -nographic -vga none -device virtio-net-pci,netdev=mynet0,mac=DE:AD:BE:EF:AB:CD,romfile= ",
     "cfg_2": "-chardev stdio,id=mux,mux=on,signal=off -device virtio-serial,romfile= -device virtconsole,chardev=mux ",
-    "cfg_3": "-serial chardev:mux -monitor chardev:mux -monitor pty -no-hpet -nodefaults ",
+    "cfg_3": "-serial chardev:mux -monitor chardev:mux -monitor pty -machine q35,hpet=off -nodefaults ",
     "cfg_var_1": "-name process=$VM_TYPEVM_$PORT,debug-threads=on ",
     "cfg_var_2": "-cpu host,host-phys-bits,pmu=$PMU ",
     "cfg_var_3": "-smp cpus=$VCPU,sockets=$SOCKETS ",


### PR DESCRIPTION
update -no-hpet based on QEMU change

[Test Components] guest-test
[Test Types] any
[Supported Devices] all-generic