### PR TITLE
spr-oe: Remove some functional tests for IFS

### DIFF
--- a/scenario/spr-oe/tests-ifs
+++ b/scenario/spr-oe/tests-ifs
@@ -6,12 +6,12 @@
 # ifs_0 scan test cases, it works on SPR(Sapphire Rapids) platform and future server
 ifs_tests.sh -m 0 -p all -n load_ifs
 # Need to set the IFS BIOS and put IFS scan blob image, please check BM/ifs/README.md
-ifs_tests.sh -m 0 -p all -b 1 -n ifs_batch
-ifs_tests.sh -m 0 -p all -b 1 -n legacy_twice_run
+#ifs_tests.sh -m 0 -p all -b 1 -n ifs_batch
+#ifs_tests.sh -m 0 -p all -b 1 -n legacy_twice_run
 #ifs_tests.sh -m 0 -p all -b 2 -n legacy_twice_run
 #ifs_tests.sh -m 0 -p all -b 3 -n legacy_twice_run
-ifs_tests.sh -m 0 -p all -b 1 -n img_version
-ifs_tests.sh -m 0 -p all -b 1 -n reload_ifs_scan_image
+#ifs_tests.sh -m 0 -p all -b 1 -n img_version
+#ifs_tests.sh -m 0 -p all -b 1 -n reload_ifs_scan_image
 
 # ifs_1 array BIST(Board Integrated System Test), it works on EMR(Emerald Rapids) and future server
 #ifs_tests.sh -m 1 -p all -n ifs_array_scan
@@ -21,4 +21,4 @@ ifs_tests.sh -m 0 -p all -b 1 -n reload_ifs_scan_image
 #ifs_tests.sh -m 1 -p ran -b 1 -n ifs_loop -t 500
 
 # Test ifs_0 all available image scan and ifs_1 scan, will skip ifs_1 scan on SPR
-test_ifs.sh
+#test_ifs.sh


### PR DESCRIPTION
The function need customers provide blob files, which blocks the all function tests.