### PR TITLE
BM: fix the issue of yogini parameter error

### DIFF
--- a/BM/workload-xsave/start_test.sh
+++ b/BM/workload-xsave/start_test.sh
@@ -22,8 +22,7 @@ fi
 # mode1: test workloads in specific break_reason
 test_single () {
   echo "trace-cmd record -e x86_fpu -F ./yogini -b $break_reason -r $repeat $option"
-  trace-cmd record -e x86_fpu -F ./yogini -b $break_reason -r $repeat $option
-  if [ $? -ne 0 ]; then
+  if ! trace-cmd record -e x86_fpu -F ./yogini -b $break_reason -r $repeat $option; then
     echo "Failed to execute trace-cmd record."
     exit 1
   fi
@@ -32,9 +31,9 @@ test_single () {
 
 # mode2: test workloads in all break_reason
 test_all () {
-for ((i=1; i<=5; i++))
+break_reasons=("yield" "sleep" "trap" "signal" "futex")
+for break_reason in "${break_reasons[@]}";
 do
-  break_reason=$i
   test_single
 done
 }


### PR DESCRIPTION
This patch is to fix the following issue:
cd workload-xsave/build
../start_test.sh -1 100 AMX memcpy MEM SSE RDTSC UMWAIT TPAUSE PAUSE DOTPROD AVX512 AVX2 AVX
trace-cmd record -e x86_fpu -F ./yogini -b 1 -r 100 -w AMX -w memcpy -w MEM -w SSE -w RDTSC -w UMWAIT -w TPAUSE -w PAUSE -w DOTPROD -w AVX512 -w AVX2 -w AVX usage: ./yogini [OPTIONS]

./yogini runs some simple micro workloads
  -w, --workload [workload_name,threads#,break#, ...]
Available workloads:  AMX memcpy MEM SSE RDTSC UMWAIT TPAUSE PAUSE DOTPROD AVX512
                      AVX2 AVX
  -r, --repeat, each instance needs to be run
  -b, --break_reason, [yield/sleep/trap/signal/futex]
For more help, see README