### PR TITLE
Remove intel_vsec check from telemetry tests

### DIFF
--- a/BM/telemetry/tests
+++ b/BM/telemetry/tests
@@ -1,6 +1,5 @@
 # This file collects the telemetry cases
 telemetry_tests.sh -t pci
-telemetry_tests.sh -t pci_driver
 telemetry_tests.sh -t telem_driver
 telemetry_tests.sh -t telem_sysfs
 telemetry_tests.sh -t telem_dev

--- a/scenario/emr-oe/tests-telemetry
+++ b/scenario/emr-oe/tests-telemetry
@@ -1,7 +1,1 @@
-# This file collects the telemetry cases
-telemetry_tests.sh -t pci
-telemetry_tests.sh -t pci_driver
-telemetry_tests.sh -t telem_driver
-telemetry_tests.sh -t telem_sysfs
-telemetry_tests.sh -t telem_dev
-telemetry_tests.sh -t telem_sysfs_common
+../../BM/telemetry/tests

--- a/scenario/spr-oe/tests-telemetry
+++ b/scenario/spr-oe/tests-telemetry
@@ -1,7 +1,1 @@
-# This file collects the telemetry cases
-telemetry_tests.sh -t pci
-telemetry_tests.sh -t pci_driver
-telemetry_tests.sh -t telem_driver
-telemetry_tests.sh -t telem_sysfs
-telemetry_tests.sh -t telem_dev
-telemetry_tests.sh -t telem_sysfs_common
+../../BM/telemetry/tests

--- a/scenario/srf-oe/tests-telemetry
+++ b/scenario/srf-oe/tests-telemetry
@@ -1,7 +1,1 @@
-# This file collects the telemetry cases
-telemetry_tests.sh -t pci
-telemetry_tests.sh -t pci_driver
-telemetry_tests.sh -t telem_driver
-telemetry_tests.sh -t telem_sysfs
-telemetry_tests.sh -t telem_dev
-telemetry_tests.sh -t telem_sysfs_common
+../../BM/telemetry/tests


### PR DESCRIPTION
Which will be covered in intel_tpmi cases