### PR TITLE
pcie_check: will continue instead of return if PCI cap is 0xff

### DIFF
--- a/BM/tools/pcie/pcie_check.c
+++ b/BM/tools/pcie/pcie_check.c
@@ -538,8 +538,10 @@ int scan_pci(void)
 
 				if ((*ptrdata != ptr_content) && (*ptrdata != 0)) {
 					if (recognize_pcie(ptrdata) == 2) {
-						printf("%02x:%02x.%x debug:pcie_check a %x %x %x\n",
-						       bus, dev, fun, bus, dev, fun);
+						printf("[ERROR] PCI %02x:%02x.%x offset 0xff,",
+						       bus, dev, fun);
+						printf("please debug:pcie_check a %x %x %x\n",
+						       bus, dev, fun);
 						munmap(ptrdata, LEN_SIZE);
 						close(fd);
 						return 2;
@@ -790,11 +792,11 @@ int find_pcie_reg(u16 cap, u32 offset, u32 size)
 						check_pcie_register(cap, offset, size);
 					} else if (result == 2) {
 						/* This PCIe ended with unknown CAP ff, mark it */
-						printf("%02x:%02x.%x debug:pcie_check a %x %x %x\n",
-						       bus, dev, func, bus, dev, func);
-						munmap(ptrdata, LEN_SIZE);
-						close(fd);
-						return 2;
+						printf("[WARN] PCIe %02x:%02x.%x error PCI CAP ff,",
+						       bus, dev, func);
+						printf("please debug:pcie_check a %x %x %x\n",
+						       bus, dev, func);
+						continue;
 					}
 				}
 				munmap(ptrdata, LEN_SIZE);
@@ -964,11 +966,11 @@ int find_pci_reg(u16 cap, u32 offset, u32 size)
 						check_pci_register((u8)cap, (u8)offset, size);
 					} else if (result == 1) {
 						/* This PCI ended with unknown CAP ff so mark it */
-						printf("%02x:%02x.%x debug:pcie_check a %x %x %x\n",
-						       bus, dev, func, bus, dev, func);
-						munmap(ptrdata, LEN_SIZE);
-						close(fd);
-						return 2;
+						printf("[WARN] PCI %02x:%02x.%x unknown CAP ff,",
+						       bus, dev, func);
+						printf("please debug:pcie_check a %x %x %x\n",
+						       bus, dev, func);
+						continue;
 					}
 				}
 				munmap(ptrdata, LEN_SIZE);

--- a/BM/tools/pcie/pcie_check.c
+++ b/BM/tools/pcie/pcie_check.c
@@ -178,15 +178,19 @@ int find_bar(void)
 	}
 	fclose(maps);
 
+	/*
+	 * In CXL QEMU environment, MMIO base address is incorrect,
+	 * so will not use dmesg check way to detect the MMIO base
+	 * address, will use mcfg way instead.
+	 * if (BASE_ADDR == 0) {
+	 * BASE_ADDR = find_base_from_dmesg();
+	 * }
+	 */
 	if (BASE_ADDR == 0) {
-		//printf("Check kconfig CONFIG_IO_STRICT_DEVMEM or v6.9 or newer kernel!\n");
-		BASE_ADDR = find_base_from_dmesg();
+		BASE_ADDR = find_base_from_mcfg();
 		if (BASE_ADDR == 0) {
-			BASE_ADDR = find_base_from_mcfg();
-			if (BASE_ADDR == 0) {
-				printf("No MMIO in dmesg, /proc/iomem and mcfg, check acpidump.\n");
-				exit(2);
-			}
+			printf("No MMIO in dmesg, /proc/iomem and mcfg, check acpidump.\n");
+			exit(2);
 		}
 	}
 #endif


### PR DESCRIPTION
Will continue instead of return if PCI cap is 0xff. Add more description info for pcie check.

Reported-by: Yi Lai <yi1.lai@intel.com>