### PR TITLE
BM: Add CMake build support

### DIFF
--- a/BM/CMakeLists.txt
+++ b/BM/CMakeLists.txt
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (c) 2024 Intel Corporation.
+# Haoliang Zhu <haoliang.zhu@intel.com>
+
+cmake_minimum_required(VERSION 3.12)
+project(lkvs)
+
+set(SUBFOLDER amx/tmul avx512vbmi cet cmpccxadd pt 
+              splitlock telemetry th tools/cpuid_check 
+	      tools/pcie umip workload-xsave xsave)
+
+foreach(subfolder ${SUBFOLDER})
+    message(STATUS "Start build ${subfolder}.")
+    add_subdirectory(${subfolder})
+    message(STATUS "Finish build ${subfolder}.")
+endforeach()

--- a/BM/amx/tmul/CMakeLists.txt
+++ b/BM/amx/tmul/CMakeLists.txt
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (c) 2024 Intel Corporation.
+# Haoliang Zhu <haoliang.zhu@intel.com>
+
+cmake_minimum_required(VERSION 3.12)
+project(tmul)
+
+# Set the build output directory
+set(BUILD_OUTPUT ${CMAKE_CURRENT_BINARY_DIR})
+
+# Set the installation prefix 
+set(CMAKE_INSTALL_PREFIX /usr/local/bin)
+
+# Set the source files
+set(SRC tmul.c)
+
+# Get target CPU information
+execute_process(
+    COMMAND ${CMAKE_C_COMPILER} -march=native -Q --help=target
+    OUTPUT_VARIABLE TARGET_CPU
+    ERROR_QUIET
+)
+
+# Check if the target CPU supports AMX
+string(REGEX MATCH "-mamx-tile[ \t]+\\[enabled\\]" AMX_SUPPORTED "${TARGET_CPU}")
+
+if(AMX_SUPPORTED)
+    message(STATUS "AMX supported by the CPU.")
+else()
+    message(WARNING "AMX not supported by the CPU - skipping tmul build.")
+    return()
+endif()
+
+# Add the executable
+add_executable(tmul ${SRC})
+
+# Link libraries
+target_link_libraries(tmul m pthread)
+
+# Install the program
+install(TARGETS tmul DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/BM/avx512vbmi/CMakeLists.txt
+++ b/BM/avx512vbmi/CMakeLists.txt
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (c) 2024 Intel Corporation.
+# Haoliang Zhu <haoliang.zhu@intel.com>
+
+cmake_minimum_required(VERSION 3.12)
+project(vbmi_test)
+
+# Set the build output directory
+set(BUILD_OUTPUT ${CMAKE_CURRENT_BINARY_DIR})
+
+# Set the installation prefix 
+set(CMAKE_INSTALL_PREFIX /usr/local/bin)
+
+# Set the source files
+set(SRC vbmi_test.c)
+
+# Get target CPU information
+execute_process(
+    COMMAND ${CMAKE_C_COMPILER} -march=native -Q --help=target
+    OUTPUT_VARIABLE TARGET_CPU
+    ERROR_QUIET
+)
+
+# Check if the target CPU supports AVX-512VBMI
+string(REGEX MATCH "-mavx512vbmi[ \t]+\\[enabled\\]" AVX512VBMI_SUPPORTED "${TARGET_CPU}")
+
+if(AVX512VBMI_SUPPORTED)
+    message(STATUS "AVX-512VBMI supported by the CPU.")
+else()
+    message(WARNING "AVX-512VBMI not supported by the CPU - skipping vbmi_test build.")
+    return()
+endif()
+
+# Add the executable
+add_executable(vbmi_test ${SRC})
+
+# Install the program
+install(TARGETS vbmi_test DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/BM/cet/CMakeLists.txt
+++ b/BM/cet/CMakeLists.txt
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (c) 2024 Intel Corporation.
+# Haoliang Zhu <haoliang.zhu@intel.com>
+
+cmake_minimum_required(VERSION 3.12)
+project(cet)
+
+# Set the build output directory
+set(BUILD_OUTPUT ${CMAKE_CURRENT_BINARY_DIR})
+
+# Set the installation prefix 
+set(CMAKE_INSTALL_PREFIX /usr/local/bin)
+
+# Set the flags
+set(CETFLAGS -O0 -fcf-protection=full -mshstk -fno-stack-check -fno-stack-protector -no-pie)
+set(SHSTKFLAGS -O0 -mshstk -fcf-protection=return -fno-stack-check -fno-stack-protector -no-pie)
+set(NOCETFLAGS -O0 -fcf-protection=none -mshstk -fno-stack-check -fno-stack-protector -no-pie)
+
+# Get the gcc version. If the version is greater than or equal to 8, build the CET programs.
+execute_process(COMMAND gcc --version OUTPUT_VARIABLE GCC_VERSION)
+string(REGEX MATCH "([0-9]+)\\." GCC_VER_MAJOR ${GCC_VERSION})
+if(GCC_VER_MAJOR GREATER_EQUAL 8)
+    set(BIN shstk_alloc test_shadow_stack quick_test wrss shstk_huge_page 
+        shstk_unlock_test shstk_cp cet_app glibc_shstk_test shstk_cpu shstk_cpu_legacy)
+else()
+    message(WARNING "GCC version is less than 8, skipping build cet.")
+    return()
+endif()
+
+# Set the kernel source path and driver path
+set(KER_SRC "/lib/modules/${CMAKE_SYSTEM_VERSION}/build")
+set(DRIVER_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cet_driver")
+
+if(EXISTS ${KER_SRC})
+    list(APPEND BIN cet_ioctl)
+else()
+    message(WARNING "Kernel source path not found, skipping build cet_ioctl.")
+endif()
+
+# Add the executable
+foreach(target ${BIN})
+    if(${target} STREQUAL "cet_ioctl")
+        # cet_ioctl need to be built in the kernel source directory
+        add_custom_target(${target}
+            COMMAND ${CMAKE_MAKE_PROGRAM} -C ${KER_SRC} M=${DRIVER_PATH} modules
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        )
+    elseif(${target} STREQUAL "cet_app")
+        # cet_app need to be built with the cet_driver
+        add_executable(${target} cet_driver/cet_app.c)
+        target_include_directories(${target} PRIVATE cet_driver)
+    else()
+        add_executable(${target} ${target}.c)
+        if(${target} MATCHES "quick_test|shstk_huge_page|glibc_shstk_test")
+            target_compile_options(${target} PRIVATE ${SHSTKFLAGS})
+        else()
+            target_compile_options(${target} PRIVATE ${NOCETFLAGS})
+        endif()
+        if(${target} STREQUAL "test_shadow_stack")
+            target_link_libraries(${target} PRIVATE pthread)
+        endif()
+    endif()
+endforeach()
+
+# Install the program
+install(TARGETS ${BIN} DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/BM/cmpccxadd/CMakeLists.txt
+++ b/BM/cmpccxadd/CMakeLists.txt
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (c) 2024 Intel Corporation.
+# Haoliang Zhu <haoliang.zhu@intel.com>
+
+cmake_minimum_required(VERSION 3.12)
+project(cmpccxadd)
+
+# Set the build output directory
+set(BUILD_OUTPUT ${CMAKE_CURRENT_BINARY_DIR})
+
+# Set the installation prefix 
+set(CMAKE_INSTALL_PREFIX /usr/local/bin)
+
+# Set the source files
+set(SRC cmpccxadd.c)
+
+# Set the global compilation flags
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall")
+
+# Add the executable
+add_executable(cmpccxadd ${SRC})
+
+# Install the program
+install(TARGETS cmpccxadd DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/BM/pt/CMakeLists.txt
+++ b/BM/pt/CMakeLists.txt
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (c) 2024 Intel Corporation.
+# Haoliang Zhu <haoliang.zhu@intel.com>
+
+cmake_minimum_required(VERSION 3.12)
+project(pt)
+
+# Set the build output directory
+set(BUILD_OUTPUT ${CMAKE_CURRENT_BINARY_DIR})
+
+# Set the installation prefix
+set(CMAKE_INSTALL_PREFIX /usr/local/bin)
+
+# Check if the header file "intel-pt.h" exists
+include(CheckIncludeFile)
+check_include_file("intel-pt.h" HAVE_INTEL_PT_H)
+if(NOT HAVE_INTEL_PT_H)
+    message(WARNING "Skipping the build of pt, please install libipt first. 
+    You can read BM/pt/README.md for more information.")
+    return()
+endif()
+# Set the global compilation flags
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -DMAINLINE -I./")
+
+# Set the source files
+set(SRC utils.c)
+
+# Set the binary files
+set(BIN cpl branch psb nonroot_test negative_test sort_test)
+
+# Set the libraries
+set(LFLAGS -L./ -lipt)
+
+foreach(target ${BIN})
+    add_executable(${target} ${target}.c ${SRC})
+    # Link libraries
+    target_link_libraries(${target} ${LFLAGS})
+endforeach()
+
+# Install the program
+install(TARGETS ${BIN} DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/BM/splitlock/CMakeLists.txt
+++ b/BM/splitlock/CMakeLists.txt
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (c) 2024 Intel Corporation.
+# Haoliang Zhu <haoliang.zhu@intel.com>
+
+cmake_minimum_required(VERSION 3.12)
+project(sl_test)
+
+# Set the build output directory
+set(BUILD_OUTPUT ${CMAKE_CURRENT_BINARY_DIR})
+
+# Set the installation prefix 
+set(CMAKE_INSTALL_PREFIX /usr/local/bin)
+
+# Set the source files
+set(SRC sl_test.c)
+
+# Add the executable
+add_executable(sl_test ${SRC})
+
+# Install the program
+install(TARGETS sl_test DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/BM/telemetry/CMakeLists.txt
+++ b/BM/telemetry/CMakeLists.txt
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (c) 2024 Intel Corporation.
+# Haoliang Zhu <haoliang.zhu@intel.com>
+
+cmake_minimum_required(VERSION 3.12)
+project(telemetry_tests)
+
+# Set the build output directory
+set(BUILD_OUTPUT ${CMAKE_CURRENT_BINARY_DIR})
+
+# Set the installation prefix 
+set(CMAKE_INSTALL_PREFIX /usr/local/bin)
+
+# Set the source files
+set(SRC telemetry_tests.c)
+
+# Add the executable
+add_executable(telemetry_tests ${SRC})
+
+# Install the program
+install(TARGETS telemetry_tests DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/BM/th/CMakeLists.txt
+++ b/BM/th/CMakeLists.txt
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (c) 2024 Intel Corporation.
+# Haoliang Zhu <haoliang.zhu@intel.com>
+
+cmake_minimum_required(VERSION 3.12)
+project(th_test)
+
+# Set the build output directory
+set(BUILD_OUTPUT ${CMAKE_CURRENT_BINARY_DIR})
+
+# Set the installation prefix 
+set(CMAKE_INSTALL_PREFIX /usr/local/bin)
+
+# Set the global compilation flags
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ggdb -Wall -fstack-protector-all")
+
+# Set the source files
+set(SRC th_test.c)
+
+# Add the executable
+add_executable(th_test ${SRC})
+
+# Install the program
+install(TARGETS th_test DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/BM/tools/cpuid_check/CMakeLists.txt
+++ b/BM/tools/cpuid_check/CMakeLists.txt
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (c) 2024 Intel Corporation.
+# Haoliang Zhu <haoliang.zhu@intel.com>
+
+cmake_minimum_required(VERSION 3.12)
+project(cpuid_check)
+
+# Set the build output directory
+set(BUILD_OUTPUT ${CMAKE_CURRENT_BINARY_DIR})
+
+# Set the installation prefix 
+set(CMAKE_INSTALL_PREFIX /usr/loacl/bin)
+
+# Set the source files
+set(SRC cpuid_check.c)
+
+# Add the executable
+add_executable(cpuid_check ${SRC})
+
+# Install the program
+install(TARGETS cpuid_check DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/BM/tools/pcie/CMakeLists.txt
+++ b/BM/tools/pcie/CMakeLists.txt
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (c) 2024 Intel Corporation.
+# Haoliang Zhu <haoliang.zhu@intel.com>
+
+cmake_minimum_required(VERSION 3.12)
+project(pcie_check)
+
+# Set the build output directory
+set(BUILD_OUTPUT ${CMAKE_CURRENT_BINARY_DIR})
+
+# Set the installation prefix 
+set(CMAKE_INSTALL_PREFIX /usr/loacl/bin)
+
+# Set the source files
+set(SRC pcie_check.c)
+
+# Add the executable
+add_executable(pcie_check ${SRC})
+
+# Install the program
+install(TARGETS pcie_check DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/BM/umip/CMakeLists.txt
+++ b/BM/umip/CMakeLists.txt
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (c) 2024 Intel Corporation.
+# Haoliang Zhu <haoliang.zhu@intel.com>
+
+cmake_minimum_required(VERSION 3.12)
+project(umip)
+
+# Set the build output directory
+set(BUILD_OUTPUT ${CMAKE_CURRENT_BINARY_DIR})
+
+# Set the installation prefix 
+set(CMAKE_INSTALL_PREFIX /usr/local/bin)
+
+# Set the source files
+set(SRC umip_utils.c)
+
+# Build umip_utils_64.o from umip_utils.c
+add_library(umip_utils_64 OBJECT ${SRC})
+
+# Build umip_exceptions_64 executable
+add_executable(umip_exceptions_64 umip_exceptions.c)
+target_link_libraries(umip_exceptions_64 umip_utils_64)
+
+# Build umip_test_basic_64 executable
+add_executable(umip_test_basic_64 umip_test_basic.c)
+target_link_libraries(umip_test_basic_64 umip_utils_64)
+
+execute_process(
+    COMMAND gcc -no-pie -c umip_utils.c -m32 -o umip_utils_32.o
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RESULT_VARIABLE RESULT
+    OUTPUT_QUIET
+    ERROR_QUIET
+)
+
+if(RESULT EQUAL 0)
+    set(COMPILER_SUPPORTS_M32 TRUE)
+    message(STATUS "32-bit compilation is supported.")
+    # Build umip_utils_32.o from umip_utils.c with -m32 flag
+    add_library(umip_utils_32 OBJECT ${SRC})
+    target_compile_options(umip_utils_32 PRIVATE "-m32")
+
+    # Build umip_exceptions_32 executable with -m32 flag
+    add_executable(umip_exceptions_32 umip_exceptions.c)
+    target_link_libraries(umip_exceptions_32 umip_utils_32 "-m32")
+    target_compile_options(umip_exceptions_32 PRIVATE "-m32")
+else()
+    message(WARNING "Skip 32-bit compilation or clean due to lack of GCC support for 32-bit architecture.")
+endif()
+
+# Install the program
+if(COMPILER_SUPPORTS_M32)
+    install(TARGETS umip_exceptions_64 umip_test_basic_64 umip_exceptions_32 DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+else()
+    install(TARGETS umip_exceptions_64 umip_test_basic_64 DESTINATION ${CMAKE_INSTALL_PREFIX})
+endif()

--- a/BM/workload-xsave/CMakeLists.txt
+++ b/BM/workload-xsave/CMakeLists.txt
@@ -7,16 +7,11 @@
 cmake_minimum_required(VERSION 3.12)
 project(Yogini)
 
-# Set the compiler
-set(CMAKE_C_COMPILER ${CROSS_COMPILE}gcc)
-
 # Set the build output directory
 set(BUILD_OUTPUT ${CMAKE_CURRENT_BINARY_DIR})
 
 # Set the installation prefix
-if(NOT CMAKE_INSTALL_PREFIX)
-    set(CMAKE_INSTALL_PREFIX /usr)
-endif()
+set(CMAKE_INSTALL_PREFIX /usr/local/bin)
 
 # Set the source files
 set(SRC
@@ -42,7 +37,7 @@ execute_process(
 )
 
 # Print information about the target CPU
-message(STATUS "Target CPU: ${TARGET_CPU}")
+# message(STATUS "Target CPU: ${TARGET_CPU}")
 
 # Function to check for CPU feature and add source files and compile definition if the feature is enabled
 function(check_cpu_feature)
@@ -92,4 +87,4 @@ add_executable(yogini ${SRC})
 target_link_libraries(yogini m pthread)
 
 # Install the program
-install(TARGETS yogini DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+install(TARGETS yogini DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/BM/xsave/CMakeLists.txt
+++ b/BM/xsave/CMakeLists.txt
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (c) 2024 Intel Corporation.
+# Haoliang Zhu <haoliang.zhu@intel.com>
+
+cmake_minimum_required(VERSION 3.12)
+project(xstate_64)
+
+# Set the build output directory
+set(BUILD_OUTPUT ${CMAKE_CURRENT_BINARY_DIR})
+
+# Set the installation prefix 
+set(CMAKE_INSTALL_PREFIX /usr/local/bin)
+
+# Set the global compilation flags
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2 -g -std=gnu99 -pthread -Wall -no-pie")
+
+# Set the source files
+set(SRC xstate.c)
+
+# Build xstate_helpers.o from xstate_helpers.c
+add_library(xstate_helpers OBJECT xstate_helpers.c)
+target_compile_options(xstate_helpers PRIVATE -mno-sse -mno-mmx -mno-sse2 -mno-avx -mno-pku)
+
+add_executable(xstate_64 ${SRC})
+
+# Link libraries
+target_link_libraries(xstate_64 PRIVATE xstate_helpers)
+target_link_libraries(xstate_64 PRIVATE rt dl)
+
+# Install the program
+install(TARGETS xstate_64 DESTINATION ${CMAKE_INSTALL_PREFIX})


### PR DESCRIPTION
1. This commit introduces CMakeLists.txt files across the BM and its subdirectories: amx/tmul avx512vbmi cet cmpccxadd pt splitlock telemetry th tools/cpuid_check tools/pcie umip xsave. Each CMakeLists.txt is configured to build the corresponding component of the project.
2. For amx/tmul and avx512vbmi, instruction set detection has been added to the CMakeLists.txt. If the target CPU does not support the corresponding instruction sets, the build will be skipped.
3. For features such as cet, umip, pt, etc., specific checks have also been added to the CMakeLists.txt. If necessary files or kernel modules are missing, the build will be skipped.
4. The installation process has been updated. You can now create a build directory within the BM directory, configure the project with CMake, compile it, and install it.
For example,
```
mkdir build
cd build
cmake ..
make
sudo make install
```
5. The CMakeLists.txt in the workload-xsave directory has been updated to ensure a consistent style.