### PR TITLE
add KVM test for lam and lass

### DIFF
--- a/BM/lass/README.md
+++ b/BM/lass/README.md
@@ -9,8 +9,8 @@ LASS achieves this by preventing memory loads/stores to user space memory in sup
 ```
 make
 # To run a specific case
-./lam -t <testcase_id>
-(for example, cpuid) ./lass m
+./lass <Case ID>
+(for example, add maps) ./lass m
 ```
 Test results (PASS or FAIL) will be printed out. 
 

--- a/BM/lass/tests
+++ b/BM/lass/tests
@@ -1,9 +1,17 @@
 # This file collects the LASS cases
-lass m  # Test get vsyscall address maps.[negative]
-lass d  # Test execute vsyscall addr 0xffffffffff600000.[negative]
-lass g  # Test call vsyscall
-lass t  # Test call vsyscall api gettimeofday
-lass r  # Test read vsyscall 0xffffffffff600000.[negative]
-lass i  # Test read random kernel space.[negative]
-lass v  # Test process_vm_readv read address 0xffffffffff600000.[negative]
-lass e  # Test vsyscall emulation.
+# Test get vsyscall address maps.[negative]
+lass m
+# Test execute vsyscall addr 0xffffffffff600000.[negative]
+lass d
+# Test call vsyscall
+lass g
+# Test call vsyscall api gettimeofday
+lass t
+# Test read vsyscall 0xffffffffff600000.[negative]
+lass r
+# Test read random kernel space.[negative]
+lass i
+# Test process_vm_readv read address 0xffffffffff600000.[negative]
+lass v
+# Test vsyscall emulation.
+lass e

--- a/KVM/qemu/feature_test.cfg
+++ b/KVM/qemu/feature_test.cfg
@@ -10,6 +10,10 @@
     variants:
         - cmpccxadd:
             feature_dir_names = "cmpccxadd"
+        - lam:
+            feature_dir_names = "lam"
+        - lass:
+            feature_dir_names = "lass"
         - umip:
             feature_dir_names = "umip"
     variants:


### PR DESCRIPTION
add lam and lass test cases for KVM.
- test cases as feature function checking 
- run lam.c in KVM guest to check function of lam
- run lass.c in KVM to guest check function of lass