### PR TITLE
BM: Fix test_print_wrg typo

### DIFF
--- a/BM/pcie/pcie_check.sh
+++ b/BM/pcie/pcie_check.sh
@@ -59,7 +59,7 @@ pci_max_link_speed() {
       test_print_trc "PCI bridge: $dev, PCIe Max Link Speed is: 32GT/s"
     else
       reg=$(decimal_to_binary "$reg" 4)
-      test_print_wrn "PCI bridge: $dev, PCIe Max Link Speed registers value $reg" 
+      test_print_wrg "PCI bridge: $dev, PCIe Max Link Speed registers value $reg"
     fi
     echo 32
   elif [[ "$gen" = "gen6" ]]; then
@@ -67,7 +67,7 @@ pci_max_link_speed() {
       test_print_trc "PCI bridge: $dev, PCIe Max Link Speed is: 64GT/s"
     else
       reg=$(decimal_to_binary "$reg" 4)
-      test_print_wrn "PCI bridge: $dev, PCIe Max Link Speed registers value $reg" 
+      test_print_wrg "PCI bridge: $dev, PCIe Max Link Speed registers value $reg"
     fi
     echo 64
   elif [[ "$gen" = "gen4" ]]; then
@@ -75,7 +75,7 @@ pci_max_link_speed() {
       test_print_trc "PCI bridge: $dev, PCIe Max Link Speed is: 16GT/s"
     else
       reg=$(decimal_to_binary "$reg" 4)
-      test_print_wrn "PCI bridge: $dev, PCIe Max Link Speed registers value $reg" 
+      test_print_wrg "PCI bridge: $dev, PCIe Max Link Speed registers value $reg"
     fi
     echo 16
   else
@@ -98,20 +98,20 @@ pci_current_link_speed() {
       test_print_trc "PCI bridge: $dev, PCIe Current Link Speed is: 32GT/s"
       echo 32
     elif [[ "$reg" -eq 3 ]]; then
-      test_print_wrn "PCI bridge: $dev, PCIe Current Link Speed is: 16GT/s (downgraded)"
+      test_print_wrg "PCI bridge: $dev, PCIe Current Link Speed is: 16GT/s (downgraded)"
       echo 16
     elif [[ "$reg" -eq 2 ]]; then
-      test_print_wrn "PCI bridge: $dev, PCIe Current Link Speed is: 8GT/s (downgraded)"
+      test_print_wrg "PCI bridge: $dev, PCIe Current Link Speed is: 8GT/s (downgraded)"
       echo 8
     elif [[ "$reg" -eq 1 ]]; then
-      test_print_wrn "PCI bridge: $dev, PCIe Current Link Speed is: 5GT/s (downgraded)"
+      test_print_wrg "PCI bridge: $dev, PCIe Current Link Speed is: 5GT/s (downgraded)"
       echo 5
     elif [[ "$reg" -eq 0 ]]; then
-      test_print_wrn "PCI bridge: $dev, PCIe Current Link Speed is: 2.5GT/s (downgraded)"
+      test_print_wrg "PCI bridge: $dev, PCIe Current Link Speed is: 2.5GT/s (downgraded)"
       echo 2.5
     else
       reg=$(decimal_to_binary "$reg" 4)
-      test_print_wrn "PCI bridge: $dev, PCIe Current Link Speed registers value $reg" 
+      test_print_wrg "PCI bridge: $dev, PCIe Current Link Speed registers value $reg"
       echo 0
     fi
   elif [[ "$gen" = "gen6" ]]; then
@@ -119,23 +119,23 @@ pci_current_link_speed() {
       test_print_trc "PCI bridge: $dev, PCIe Current Link Speed is: 64GT/s"
       echo 64
     elif [[ "$reg" -eq 4 ]]; then
-      test_print_wrn "PCI bridge: $dev, PCIe Current Link Speed is: 32GT/s (downgraded)"
+      test_print_wrg "PCI bridge: $dev, PCIe Current Link Speed is: 32GT/s (downgraded)"
       echo 32
     elif [[ "$reg" -eq 3 ]]; then
-      test_print_wrn "PCI bridge: $dev, PCIe Current Link Speed is: 16GT/s (downgraded)"
+      test_print_wrg "PCI bridge: $dev, PCIe Current Link Speed is: 16GT/s (downgraded)"
       echo 16
     elif [[ "$reg" -eq 2 ]]; then
-      test_print_wrn "PCI bridge: $dev, PCIe Current Link Speed is: 8GT/s (downgraded)"
+      test_print_wrg "PCI bridge: $dev, PCIe Current Link Speed is: 8GT/s (downgraded)"
       echo 8
     elif [[ "$reg" -eq 1 ]]; then
-      test_print_wrn "PCI bridge: $dev, PCIe Current Link Speed is: 5GT/s (downgraded)"
+      test_print_wrg "PCI bridge: $dev, PCIe Current Link Speed is: 5GT/s (downgraded)"
       echo 5
     elif [[ "$reg" -eq 0 ]]; then
-      test_print_wrn "PCI bridge: $dev, PCIe Current Link Speed is: 2.5GT/s (downgraded)"
+      test_print_wrg "PCI bridge: $dev, PCIe Current Link Speed is: 2.5GT/s (downgraded)"
       echo 2.5
     else
       reg=$(decimal_to_binary "$reg" 4)
-      test_print_wrn "PCI bridge: $dev, PCIe Current Link Speed registers value $reg" 
+      test_print_wrg "PCI bridge: $dev, PCIe Current Link Speed registers value $reg"
       echo 0
     fi
   elif [[ "$gen" = "gen4" ]]; then
@@ -143,17 +143,17 @@ pci_current_link_speed() {
       test_print_trc "PCI bridge: $dev, PCIe Current Link Speed is: 16GT/s"
       echo 16
     elif [[ "$reg" -eq 2 ]]; then
-      test_print_wrn "PCI bridge: $dev, PCIe Current Link Speed is: 8GT/s (downgraded)"
+      test_print_wrg "PCI bridge: $dev, PCIe Current Link Speed is: 8GT/s (downgraded)"
       echo 8
     elif [[ "$reg" -eq 1 ]]; then
-      test_print_wrn "PCI bridge: $dev, PCIe Current Link Speed is: 5GT/s (downgraded)"
+      test_print_wrg "PCI bridge: $dev, PCIe Current Link Speed is: 5GT/s (downgraded)"
       echo 5
     elif [[ "$reg" -eq 0 ]]; then
-      test_print_wrn "PCI bridge: $dev, PCIe Current Link Speed is: 2.5GT/s (downgraded)"
+      test_print_wrg "PCI bridge: $dev, PCIe Current Link Speed is: 2.5GT/s (downgraded)"
       echo 2.5
     else
       reg=$(decimal_to_binary "$reg" 4)
-      test_print_wrn "PCI bridge: $dev, PCIe Current Link Speed registers value $reg" 
+      test_print_wrg "PCI bridge: $dev, PCIe Current Link Speed registers value $reg"
       echo 0
     fi
   else
@@ -191,7 +191,7 @@ pci_supported_link_speed() {
       test_print_trc "PCI bridge: $dev, PCIe Supported Link Speeds: 2.5GT/s"
       echo "2.5GT/s"
     else
-      test_print_wrn "PCI bridge: $dev, PCIe Supported Link Speeds registers value $reg" 
+      test_print_wrg "PCI bridge: $dev, PCIe Supported Link Speeds registers value $reg"
       echo "0"
     fi
   elif [[ "$gen" = "gen6" ]]; then
@@ -214,7 +214,7 @@ pci_supported_link_speed() {
       test_print_trc "PCI bridge: $dev, PCIe Supported Link Speeds: 2.5GT/s"
       echo "2.5GT/s"
     else
-      test_print_wrn "PCI bridge: $dev, PCIe Supported Link Speeds registers value $reg" 
+      test_print_wrg "PCI bridge: $dev, PCIe Supported Link Speeds registers value $reg"
       echo "0"
     fi
   elif [[ "$gen" = "gen4" ]]; then
@@ -231,7 +231,7 @@ pci_supported_link_speed() {
       test_print_trc "PCI bridge: $dev, PCIe Supported Link Speeds: 2.5GT/s"
       echo "2.5GT/s"
     else
-      test_print_wrn "PCI bridge: $dev, PCIe Supported Link Speeds registers value $reg" 
+      test_print_wrg "PCI bridge: $dev, PCIe Supported Link Speeds registers value $reg"
       echo "0"
     fi
   else
@@ -255,7 +255,7 @@ pci_target_link_speed() {
       echo 32
     else
       reg=$(decimal_to_binary "$reg" 4)
-      test_print_wrn "PCI bridge: $dev, PCIe Target Link Speed registers value $reg" 
+      test_print_wrg "PCI bridge: $dev, PCIe Target Link Speed registers value $reg"
       echo 0
     fi
   elif [[ "$gen" = "gen6" ]]; then
@@ -264,7 +264,7 @@ pci_target_link_speed() {
       echo 64
     else
       reg=$(decimal_to_binary "$reg" 4)
-      test_print_wrn "PCI bridge: $dev, PCIe Target Link Speed registers value $reg"
+      test_print_wrg "PCI bridge: $dev, PCIe Target Link Speed registers value $reg"
       echo 0
     fi
   elif [[ "$gen" = "gen4" ]]; then
@@ -273,7 +273,7 @@ pci_target_link_speed() {
       echo 16
     else
       reg=$(decimal_to_binary "$reg" 4)
-      test_print_wrn "PCI bridge: $dev, PCIe Target Link Speed registers value $reg"
+      test_print_wrg "PCI bridge: $dev, PCIe Target Link Speed registers value $reg"
       echo 0
     fi
   else

--- a/BM/tdx-guest/tdx_dep_check.sh
+++ b/BM/tdx-guest/tdx_dep_check.sh
@@ -70,8 +70,8 @@ qemu_tdx_cap_check() {
   if qemu-system-x86_64 -object help | grep -q "tdx-guest"; then
     test_print_trc "QEMU has TDX capability."
   else
-    test_print_wrn "default QEMU qemu-system-x86_64 does not have TDX capability."
-    test_print_wrn "if there is off-tree QEMU with TDX capability, please specify the path."
+    test_print_wrg "default QEMU qemu-system-x86_64 does not have TDX capability."
+    test_print_wrg "if there is off-tree QEMU with TDX capability, please specify the path."
     die "QEMU TDX capability check FAIL."
     return 1
   fi
@@ -83,7 +83,7 @@ virtual_bios_tdx_check() {
   if find / -name "OVMF_*.fd" 2>/dev/null; then
     test_print_trc "Virtual BIOS has TDX support."
   else
-    test_print_wrn "can't find any OVMF EDK2 BIOS file, please check if virtual BIOS has TDX support."
+    test_print_wrg "can't find any OVMF EDK2 BIOS file, please check if virtual BIOS has TDX support."
     die "Virtual BIOS TDX support check FAIL."
     return 1
   fi
@@ -97,7 +97,7 @@ mainline_kernel_check() {
     [ "$(uname -r | awk -F'.' '{print $2}')" -ge 10 ]; then
     test_print_trc "Mainline kernel version is used."
   else
-    test_print_wrn "Kernel version is not mainline or less than 5.10."
+    test_print_wrg "Kernel version is not mainline or less than 5.10."
     die "Mainline kernel version check FAIL."
     return 1
   fi


### PR DESCRIPTION
Fix the 'test_print_wrn' to 'test_print_wrg'.