### PR TITLE
KVM: Add 8 hugepage test cases for TD and Non-TD

### DIFF
--- a/KVM/qemu/boot_vm_in_hugepage.cfg
+++ b/KVM/qemu/boot_vm_in_hugepage.cfg
@@ -1,0 +1,39 @@
+- boot_vm_in_hugepage:
+    virt_test_type = qemu
+    type = boot
+    kill_vm_on_error = yes
+    login_timeout = 240
+    setup_hugepages = yes
+    pre_command_noncritical = yes
+    pre_command = "echo 3 > /proc/sys/vm/drop_caches"
+    variants:
+        - 2M:
+            variants:
+                - @default:
+                    hugepage_cpu_flag = "pse"
+                    hugepage_match_str = "default_hugepagesz=2M"
+                    expected_hugepage_size = 2048
+                - specify_hp_file:
+                    kernel_hp_file = "/sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages"
+        - 1G:
+            variants:
+                - @default:
+                    # Notes:
+                    #    Before start testing, please ensure your host OS support 1G hugepage.
+                    #    Please don't forget to update host kernel line to enable 1G hugepage
+                    #    support and ensure your host have enough memory to create guest memory.
+                    hugepage_cpu_flag = "pdpe1gb"
+                    hugepage_match_str = "default_hugepagesz=1G"
+                    expected_hugepage_size = 1048576
+                - specify_hp_file:
+                    kernel_hp_file = "/sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages"
+                    mem = 4096
+    variants:
+        - vm:
+            reboot_method = shell
+            reboot_count = 1
+        - tdvm:
+            machine_type_extra_params = "kernel-irqchip=split"
+            vm_secure_guest_type = tdx
+            auto_cpu_model = "no"
+            cpu_model = host


### PR DESCRIPTION
Test cases cover huge page size 2M and 1G.
Other dimension:
 * Default hugepage file is /proc/sys/vm/nr_hugepages
 * Specific hugepage file is /sys/kernel/mm/hugepages/hugepages-*/nr_hugepages