### PR TITLE
New Test: add 14 TCs to cover TDX dynamic pamt feature

### DIFF
--- a/BM/tdx-host/qemu_dpamt.sh
+++ b/BM/tdx-host/qemu_dpamt.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (c) 2025 Intel Corporation
+
+# Author:   Hongyu Ning <hongyu.ning@intel.com>
+# History:  13, Jun., 2025 - Hongyu Ning - creation
+
+# @desc simple script to launch TDVMs in different configurations
+# @ $1 CPU number
+# @ $2 Memory size in GB
+# @ $3 PORT number for ssh forwarding
+# @ $4 GUEST_IMAGE for VM launching
+# @note detailed qemu configuration to be revised based on qemu TDVM launching requirements
+
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+echo "$SCRIPT_DIR"
+
+# TDX guest kernel
+KERNEL_IMAGE="/guest/kernel/in_use/vmlinuz-xxx-yyy-zzz"
+
+# OVMF
+BIOS_IMAGE="/ovmf/in_use/OVMF.xx_yy_zz.fd"
+
+# QEMU
+QEMU_IMAGE="/qemu/in_use/qemu-system-x86_64.xx_yy_zz"
+
+# Common test parameter
+CPUS=$1
+MEM=$2
+PORT=$3
+GUEST_IMAGE=$4
+CID=$(( "$PORT" - 10000 ))
+TELNET=$(( "$PORT" - 1000 ))
+
+# All dynamic TDX pre-check work will be done in tdx_dpamt_test.sh
+
+
+# TDVM launching
+"${QEMU_IMAGE}" \
+  -accel kvm \
+  -no-reboot \
+  -name process=td_pamt_"${PORT}",debug-threads=on \
+  -cpu host,host-phys-bits,pmu=off \
+  -smp cpus="${CPUS}" \
+  -m "${MEM}"G \
+  -object '{"qom-type":"tdx-guest","id":"tdx","sept-ve-disable":true}' \
+  -object memory-backend-ram,id=ram1,size="${MEM}"G \
+  -machine q35,hpet=off,kernel_irqchip=split,confidential-guest-support=tdx,memory-backend=ram1 \
+  -bios "${BIOS_IMAGE}" \
+  -nographic \
+  -vga none \
+  -device virtio-net-pci,netdev=mynet0,mac=00:16:3E:68:08:FF,romfile= \
+  -netdev user,id=mynet0,hostfwd=tcp::"${PORT}"-:22 \
+  -device vhost-vsock-pci,guest-cid="${CID}" \
+  -chardev stdio,id=mux,mux=on,signal=off \
+  -device virtio-serial,romfile= \
+  -device virtconsole,chardev=mux \
+  -serial chardev:mux \
+  -monitor chardev:mux \
+  -drive file="${GUEST_IMAGE}",if=virtio,format=raw \
+  -kernel "${KERNEL_IMAGE}" \
+  -append "root=/dev/vda3 ro console=hvc0 earlyprintk=ttyS0 earlyprintk l1tf=off nokaslr efi=debug mce=off accept_memory=lazy" \
+  -monitor pty \
+  -monitor telnet:127.0.0.1:"${TELNET}",server,nowait \
+  -machine hpet=off \
+  -nodefaults

--- a/BM/tdx-host/qemu_legacy.sh
+++ b/BM/tdx-host/qemu_legacy.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (c) 2025 Intel Corporation
+
+# Author:   Hongyu Ning <hongyu.ning@intel.com>
+# History:  13, Jun., 2025 - Hongyu Ning - creation
+
+# @desc simple script to launch legacy VMs in different configurations
+# @ $1 CPU number
+# @ $2 Memory size in GB
+# @ $3 PORT number for ssh forwarding
+# @ note detailed qemu configuration to be revised based on qemu legacy VM launching requirements
+
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+echo "$SCRIPT_DIR"
+
+# TDX guest kernel
+KERNEL_IMAGE="/guest/kernel/in_use/vmlinuz-xxx-yyy-zzz"
+
+# OVMF
+BIOS_IMAGE="/ovmf/in_use/OVMF.xx_yy_zz.fd"
+
+# QEMU
+QEMU_IMAGE="/qemu/in_use/qemu-system-x86_64.xx_yy_zz"
+
+# GUEST_IMAGE
+GUEST_IMAGE="/guest/os/image/in_use/guest-os.xx.img"
+
+# Common test parameter
+CPUS=$1
+MEM=$2
+PORT=$3
+CID=$(( "$PORT" - 10000 ))
+TELNET=$(( "$PORT" - 1000 ))
+
+# All dynamic TDX pre-check work will be done in tdx_dynamic_pamt_test.sh
+
+
+# TDVM launching
+"${QEMU_IMAGE}" \
+  -accel kvm \
+  -no-reboot \
+  -name process=vm_"${PORT}",debug-threads=on \
+  -cpu host,host-phys-bits,pmu=off \
+  -smp cpus="${CPUS}" \
+  -m "${MEM}"G \
+  -object memory-backend-ram,id=ram1,size="${MEM}"G \
+  -machine q35,hpet=off,kernel_irqchip=split,memory-backend=ram1 \
+  -bios "${BIOS_IMAGE}" \
+  -nographic \
+  -vga none \
+  -device virtio-net-pci,netdev=mynet0,mac=00:16:3E:68:08:FF,romfile= \
+  -netdev user,id=mynet0,hostfwd=tcp::"${PORT}"-:22 \
+  -device vhost-vsock-pci,guest-cid="${CID}" \
+  -chardev stdio,id=mux,mux=on,signal=off \
+  -device virtio-serial,romfile= \
+  -device virtconsole,chardev=mux \
+  -serial chardev:mux \
+  -monitor chardev:mux \
+  -drive file="${GUEST_IMAGE}",if=virtio,format=raw \
+  -kernel "${KERNEL_IMAGE}" \
+  -append "root=/dev/vda3 ro console=hvc0 earlyprintk=ttyS0 earlyprintk l1tf=off nokaslr efi=debug mce=off" \
+  -monitor pty \
+  -monitor telnet:127.0.0.1:"${TELNET}",server,nowait \
+  -machine hpet=off \
+  -nodefaults

--- a/BM/tdx-host/tdx_dep_check.sh
+++ b/BM/tdx-host/tdx_dep_check.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (c) 2025 Intel Corporation
+
+# Author:   Hongyu Ning <hongyu.ning@intel.com>
+#
+# History:  17, Jun., 2025 - Hongyu Ning - creation
+
+
+# @desc This script do basic TD dependency check in TDX host environment
+#       test binary is based msr-tools from OS distros
+
+###################### Variables ######################
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+echo "$SCRIPT_DIR"
+source common.sh
+
+while getopts :t: arg; do
+  case $arg in
+    t)
+      DEP_CASE=$OPTARG
+      ;;
+    *)
+      test_print_err "Must supply an argument to -$OPTARG."
+      exit 1
+      ;;
+  esac
+done
+
+###################### Functions ######################
+seamrr_check() {
+  #SEAMRR represents SEAM Ranger Register, which is used by the BIOS 
+  #to help configure the SEAM memory range, where the TDX module is 
+  #loaded and executed
+  #bit 11 of IA32_SEAMRR_PHYS_MAS MSR is set, indicates SEAMRR is enabled correctly
+  #check on that could basically tell the HW support and enabling successfuly of TDX
+  if rdmsr 0x1401 -f 11:11 | grep 1; then
+    test_print_trc "SEAMRR enabled correctly for further TDX SW enabling."
+  else
+    die "SEAMRR check FAIL."
+    return 1
+  fi
+}
+
+tdx_parameter_check() {
+  #check if kernel module kvm_intel parameter tdx is Y
+  #if yes, it indicates tdx enabled correctly on host kernel
+  if [ -f "/sys/module/kvm_intel/parameters/tdx" ] && \
+    [ "$(cat /sys/module/kvm_intel/parameters/tdx)" = "Y" ]; then
+    test_print_trc "TDX enabled from host kernel KVM POV."
+  else
+    die "TDX kvm_intel module parameter check FAIL."
+    return 1
+  fi
+}
+
+###################### Do Works ######################
+case "$DEP_CASE" in
+  hw_dep_check)
+    seamrr_check
+    ;;
+  other_dep_check1)
+    tdx_parameter_check
+    ;;
+  :)
+    test_print_err "Must specify the attest case option by [-t]"
+    exit 1
+    ;;
+  \?)
+    test_print_err "Input test case option $DEP_CASE is not supported"
+    exit 1
+    ;;
+esac

--- a/BM/tdx-host/tdx_dpamt_test.sh
+++ b/BM/tdx-host/tdx_dpamt_test.sh
@@ -1,0 +1,651 @@
+#!/usr/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (c) 2025 Intel Corporation
+
+# Author:   Hongyu Ning <hongyu.ning@intel.com>
+# History:  10, Jun., 2025 - Hongyu Ning - creation
+
+# @desc This script is top level TDX KVM host dynamic pamt test
+# @functions provided:
+#  #   - basic pamt prerequisites check
+#  #   - launch TDVM or legacy VM
+#  #   - shutdown TDVM or legacy VM
+#  #   - dynamic pamt functional check
+
+###################### Variables ######################
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+echo "$SCRIPT_DIR"
+
+# Guest OS root account password for sshpass usage
+# This should be set to the actual password of the guest OS root account
+SSHPASS="guest_os_root_password"
+export SSHPASS
+GUEST_IMAGE_1="/guest/os/image/in_use/guest-os.xx.1.img"
+GUEST_IMAGE_2="/guest/os/image/in_use/guest-os.xx.2.img"
+GUEST_IMAGE_3="/guest/os/image/in_use/guest-os.xx.3.img"
+GUEST_IMAGE_4="/guest/os/image/in_use/guest-os.xx.4.img"
+GUEST_IMAGE_5="/guest/os/image/in_use/guest-os.xx.5.img"
+
+###################### Functions ######################
+# helper function
+usage() {
+  cat <<-EOF
+  usage: ./${0##*/}
+  -t testcase number to run
+  -h HELP info
+EOF
+}
+
+# functiont to do basic TDX KVM host enabling check
+tdx_basic_check(){
+  #check if TDX KVM host is booted with TDX enabled
+  dmesg | grep -i "tdx" | grep -iq "module initialized" || \
+  die "TDX KVM host not booted with TDX enabled, \
+  please check host kernel tdx enabling setup."
+  test_print_trc "TDX module initialized correctly"
+  #check if TDX KVM host is booted with TDX enabled
+  if [ "$(cat /sys/module/kvm_intel/parameters/tdx)" = "Y" ]; then
+    test_print_trc "TDX KVM host booted with TDX enabled"
+  else
+    die "TDX KVM host not booted with TDX enabled, \
+    please check host kernel tdx enabling setup."
+  fi
+}
+
+# function to do basic TDX KVM host dynamic pamt check
+pamt_basic_check() {
+  # check if TDX KVM host is booted with pamt enabled
+  dmesg | grep -i "tdx" | grep -iq "enable dynamic pamt" || \
+  die "TDX KVM host not booted with dynamic pamt enabled, \
+  please check host kernel pamt enabling setup."
+  test_print_trc "TDX KVM host booted with dynamic pamt enabled" 
+  # check /proc/meminfo TDX field exists and value is zero
+  grep -iq "tdx" /proc/meminfo || \
+  die "TDX KVM host not booted with TDX enabled, \
+  please check host kernel tdx enabling setup."
+  local tdx_meminfo
+  tdx_meminfo=$(grep -i "tdx:" /proc/meminfo | awk '{print $2}')
+  if [ "$tdx_meminfo" -eq 0 ]; then
+    test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero"
+  else
+    die "TDX KVM host /proc/meminfo tdx field value is not zero, \
+    please check host kernel pamt enabling setup."
+  fi
+}
+
+# functiont to check and return pamt value in /proc/meminfo
+pamt_meminfo_tdx(){
+  local tdx_meminfo
+  tdx_meminfo=$(grep -i "tdx:" /proc/meminfo | awk '{print $2}')
+  if [ -z "$tdx_meminfo" ]; then
+    die "TDX KVM host /proc/meminfo tdx field not found, \
+    please check host kernel pamt enabling setup."
+  else
+    echo "$tdx_meminfo"
+  fi
+}
+
+# function to shutdown TDVM or legacy VM with port number passed in
+vm_shutdown(){
+  local PORT="$1"
+  if [ -z "$PORT" ]; then
+    die "Port number not provided for TDVM shutdown."
+  fi
+  # Shutdown TDVM with the given port number
+  sshpass -e ssh -p "$PORT" -o StrictHostKeyChecking=no root@localhost << EOF
+    systemctl reboot --reboot-argument=now
+EOF
+}
+
+###################### Do Works #######################
+cd "$(dirname "$0")" 2>/dev/null || exit 1
+source ../.env
+
+## PART 0: prepare test prerequisites ##
+if [ ! "$(which sshpass)" ]; then
+  dnf install -y sshpass > /dev/null
+  apt install -y sshpass > /dev/null
+else
+  test_print_trc "sshpass prerequisites is ready for use"
+fi
+
+while getopts :t:h arg; do
+  case $arg in
+    t)
+      TESTCASE=$OPTARG
+      ;;
+    h)
+      usage && exit 0
+      ;;
+    :)
+      test_print_err "Must supply an argument to -$OPTARG."
+      usage && exit 1
+      ;;
+    \?)
+      test_print_err "Invalid Option -$OPTARG ignored."
+      usage && exit 1
+      ;;
+  esac
+done
+
+case $TESTCASE in
+  # basic KVM host TDX enabling check
+  0)
+    tdx_basic_check;
+    ;;
+  # basic KVM host dynamic pamt check
+  1)
+    tdx_basic_check;
+    pamt_basic_check;
+    ;;
+  # 1 TDVM of 1 VCPU and 1GB MEM launch & shutdown, with dpamt check
+  2)
+    tdx_basic_check;
+    pamt_basic_check;
+    # launch TDVM with 1 vCPU, 1GB memory and port 10021
+    ./qemu_dpamt.sh 1 1 10021 $GUEST_IMAGE_1 &
+    sleep 10
+    # check if TDX KVM host /proc/meminfo tdx field value is zero
+    tdx_meminfo=$(pamt_meminfo_tdx)
+    if [ "$tdx_meminfo" -eq 0 ]; then
+      die "TDX KVM host /proc/meminfo tdx field value is still zero after TDVM launch, \
+      please check host kernel pamt enabling setup."
+    else
+      test_print_trc "TDX KVM host /proc/meminfo tdx field is $tdx_meminfo after TDVM lauched"
+    fi
+    # shutdown TDVM
+    vm_shutdown 10021 || die "Failed to shutdown TDVM"
+    sleep 10
+    # check if TDX KVM host /proc/meminfo tdx field value is zero
+    tdx_meminfo=$(pamt_meminfo_tdx)
+    if [ "$tdx_meminfo" -eq 0 ]; then
+      test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after TDVM shutdown"
+    else
+      die "TDX KVM host /proc/meminfo tdx field value is not zero after TDVM shutdown, \
+      please check host kernel pamt enabling setup."
+    fi
+    ;;
+  # 1 TDVM of 1 VCPU and 4GB MEM launch & shutdown, with dpamt check
+  3)
+    tdx_basic_check;
+    pamt_basic_check;
+    # launch TDVM with 1 vCPU, 4GB memory and port 10021
+    ./qemu_dpamt.sh 1 4 10021 $GUEST_IMAGE_1 &
+    sleep 20
+    # check if TDX KVM host /proc/meminfo tdx field value is zero
+    tdx_meminfo=$(pamt_meminfo_tdx)
+    if [ "$tdx_meminfo" -eq 0 ]; then
+      die "TDX KVM host /proc/meminfo tdx field value is still zero after TDVM launch, \
+      please check host kernel pamt enabling setup."
+    else
+      test_print_trc "TDX KVM host /proc/meminfo tdx field is $tdx_meminfo after TDVM lauched"
+    fi
+    # shutdown TDVM
+    vm_shutdown 10021 || die "Failed to shutdown TDVM"
+    sleep 10
+    # check if TDX KVM host /proc/meminfo tdx field value is zero
+    tdx_meminfo=$(pamt_meminfo_tdx)
+    if [ "$tdx_meminfo" -eq 0 ]; then
+      test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after TDVM shutdown"
+    else
+      die "TDX KVM host /proc/meminfo tdx field value is not zero after TDVM shutdown, \
+      please check host kernel pamt enabling setup."
+    fi
+    ;;
+  # 1 TDVM of 1 VCPU and 96GB MEM launch & shutdown, with dpamt check
+  4)
+    tdx_basic_check;
+    pamt_basic_check;
+    # launch TDVM with 1 vCPU, 96GB memory and port 10021
+    ./qemu_dpamt.sh 1 96 10021 $GUEST_IMAGE_1 &
+    sleep 60
+    # check if TDX KVM host /proc/meminfo tdx field value is zero
+    tdx_meminfo=$(pamt_meminfo_tdx)
+    if [ "$tdx_meminfo" -eq 0 ]; then
+      die "TDX KVM host /proc/meminfo tdx field value is still zero after TDVM launch, \
+      please check host kernel pamt enabling setup."
+    else
+      test_print_trc "TDX KVM host /proc/meminfo tdx field is $tdx_meminfo after TDVM lauched"
+    fi
+    # shutdown TDVM
+    vm_shutdown 10021 || die "Failed to shutdown TDVM"
+    sleep 10
+    # check if TDX KVM host /proc/meminfo tdx field value is zero
+    tdx_meminfo=$(pamt_meminfo_tdx)
+    if [ "$tdx_meminfo" -eq 0 ]; then
+      test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after TDVM shutdown"
+    else
+      die "TDX KVM host /proc/meminfo tdx field value is not zero after TDVM shutdown, \
+      please check host kernel pamt enabling setup."
+    fi
+    ;;
+  # 2 TDVMs of 1 VCPU and 1GB MEM launch & shutdown, with dpamt check
+  5)
+    tdx_basic_check;
+    pamt_basic_check;
+    # launch TDVM1 with 1 vCPU, 1GB memory and port 10021
+    ./qemu_dpamt.sh 1 1 10021 $GUEST_IMAGE_1 &
+    # launch TDVM2 with 1 vCPU, 1GB memory and port 10022
+    ./qemu_dpamt.sh 1 1 10022 $GUEST_IMAGE_2 &
+    # wait for TDVMs to be launched
+    sleep 20
+    # check if TDX KVM host /proc/meminfo tdx field value is zero
+    tdx_meminfo=$(pamt_meminfo_tdx)
+    if [ "$tdx_meminfo" -eq 0 ]; then
+      die "TDX KVM host /proc/meminfo tdx field value is still zero after TDVMs launch, \
+      please check host kernel pamt enabling setup."
+    else
+      test_print_trc "TDX KVM host /proc/meminfo tdx field is $tdx_meminfo after TDVMs lauched"
+    fi
+    # shutdown TDVM1
+    vm_shutdown 10021 || die "Failed to shutdown TDVM1"
+    sleep 10
+    # check if TDX KVM host /proc/meminfo tdx field value is not zero since TDVM2 is still alive
+    tdx_meminfo=$(pamt_meminfo_tdx)
+    if [ "$tdx_meminfo" -eq 0 ]; then
+      die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM1 shutdown"
+    else
+      test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM1 shutdown"
+    fi
+    # shutdown TDVM2
+    vm_shutdown 10022 || die "Failed to shutdown TDVM2"
+    sleep 10
+    # check if TDX KVM host /proc/meminfo tdx field value is zero
+    tdx_meminfo=$(pamt_meminfo_tdx)
+    if [ "$tdx_meminfo" -eq 0 ]; then
+      test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after TDVM2 shutdown"
+    else
+      die "TDX KVM host /proc/meminfo tdx field value is not zero $tdx_meminfo after TDVM2 shutdown, \
+      please check host kernel pamt enabling setup."
+    fi
+    ;;
+  # 2 TDVMs of 1 VCPU and 4GB MEM launch & shutdown, with dpamt check
+  6)
+    tdx_basic_check;
+    pamt_basic_check;
+    # launch TDVM1 with 1 vCPU, 4GB memory and port 10021
+    ./qemu_dpamt.sh 1 4 10021 $GUEST_IMAGE_1 &
+    # launch TDVM2 with 1 vCPU, 4GB memory and port 10022
+    ./qemu_dpamt.sh 1 4 10022 $GUEST_IMAGE_2 &
+    # wait for TDVMs to be launched
+    sleep 30
+    # check if TDX KVM host /proc/meminfo tdx field value is zero
+    tdx_meminfo=$(pamt_meminfo_tdx)
+    if [ "$tdx_meminfo" -eq 0 ]; then
+      die "TDX KVM host /proc/meminfo tdx field value is still zero after TDVMs launch, \
+      please check host kernel pamt enabling setup."
+    else
+      test_print_trc "TDX KVM host /proc/meminfo tdx field is $tdx_meminfo after TDVMs lauched"
+    fi
+    # shutdown TDVM1
+    vm_shutdown 10021 || die "Failed to shutdown TDVM1"
+    sleep 10
+    # check if TDX KVM host /proc/meminfo tdx field value is not zero since TDVM2 is still alive
+    tdx_meminfo=$(pamt_meminfo_tdx)
+    if [ "$tdx_meminfo" -eq 0 ]; then
+      die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM1 shutdown"
+    else
+      test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM1 shutdown"
+    fi
+    # shutdown TDVM2
+    vm_shutdown 10022 || die "Failed to shutdown TDVM2"
+    sleep 10
+    # check if TDX KVM host /proc/meminfo tdx field value is zero
+    tdx_meminfo=$(pamt_meminfo_tdx)
+    if [ "$tdx_meminfo" -eq 0 ]; then
+      test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after TDVM2 shutdown"
+    else
+      die "TDX KVM host /proc/meminfo tdx field value is not zero $tdx_meminfo after TDVM2 shutdown, \
+      please check host kernel pamt enabling setup."
+    fi
+    ;;
+  # 2 TDVMs of 1 VCPU and 96GB MEM launch & shutdown, with dpamt check
+  7)
+    tdx_basic_check;
+    pamt_basic_check;
+    # launch TDVM1 with 1 vCPU, 96GB memory and port 10021
+    ./qemu_dpamt.sh 1 96 10021 $GUEST_IMAGE_1 &
+    # launch TDVM2 with 1 vCPU, 96GB memory and port 10022
+    ./qemu_dpamt.sh 1 96 10022 $GUEST_IMAGE_2 &
+    # wait for TDVMs to be launched
+    sleep 60
+    # check if TDX KVM host /proc/meminfo tdx field value is zero
+    tdx_meminfo=$(pamt_meminfo_tdx)
+    if [ "$tdx_meminfo" -eq 0 ]; then
+      die "TDX KVM host /proc/meminfo tdx field value is still zero after TDVMs launch, \
+      please check host kernel pamt enabling setup."
+    else
+      test_print_trc "TDX KVM host /proc/meminfo tdx field is $tdx_meminfo after TDVMs lauched"
+    fi
+    # shutdown TDVM1
+    vm_shutdown 10021 || die "Failed to shutdown TDVM1"
+    sleep 10
+    # check if TDX KVM host /proc/meminfo tdx field value is not zero since TDVM2 is still alive
+    tdx_meminfo=$(pamt_meminfo_tdx)
+    if [ "$tdx_meminfo" -eq 0 ]; then
+      die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM1 shutdown"
+    else
+      test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM1 shutdown"
+    fi
+    # shutdown TDVM2
+    vm_shutdown 10022 || die "Failed to shutdown TDVM2"
+    sleep 10
+    # check if TDX KVM host /proc/meminfo tdx field value is zero
+    tdx_meminfo=$(pamt_meminfo_tdx)
+    if [ "$tdx_meminfo" -eq 0 ]; then
+      test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after TDVM2 shutdown"
+    else
+      die "TDX KVM host /proc/meminfo tdx field value is not zero $tdx_meminfo after TDVM2 shutdown, \
+      please check host kernel pamt enabling setup."
+    fi
+    ;;
+  # [negative] 1 VPCU and 1GB MEM legacy VM launch and dpamt check
+  8)
+    tdx_basic_check;
+    pamt_basic_check;
+    # launch legacy VM with 1 vCPU, 1GB memory and port 10021
+    ./qemu_legacy.sh 1 1 10021 &
+    sleep 10
+    # check if TDX KVM host /proc/meminfo tdx field value is zero
+    tdx_meminfo=$(pamt_meminfo_tdx)
+    if [ "$tdx_meminfo" -eq 0 ]; then
+      test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after legacy VM lauched"
+    else
+      die "TDX KVM host /proc/meminfo tdx field value is not zero after legacy VM lauched, \
+      please check host kernel pamt enabling setup."
+    fi
+    # shutdown legacy VM
+    vm_shutdown 10021 || die "Failed to shutdown legacy VM"
+    sleep 10
+    # check if TDX KVM host /proc/meminfo tdx field value is zero
+    tdx_meminfo=$(pamt_meminfo_tdx)
+    if [ "$tdx_meminfo" -eq 0 ]; then
+      test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after legacy VM shutdown"
+    else
+      die "TDX KVM host /proc/meminfo tdx field value is not zero after legacy VM shutdown, \
+      please check host kernel pamt enabling setup."
+    fi
+    ;;
+  # [negative] 1 VCPU and 1GB TDVM and legacy VM launch and dpamt check
+  9)
+    tdx_basic_check;
+    pamt_basic_check;
+    # launch TDVM with 1 vCPU, 1GB memory and port 10021
+    ./qemu_dpamt.sh 1 1 10021 $GUEST_IMAGE_1 &
+    # launch legacy VM with 1 vCPU, 1GB memory and port 10022
+    ./qemu_legacy.sh 1 1 10022 &
+    # wait for TDVM and legacy VM to be launched
+    sleep 10
+    # check if TDX KVM host /proc/meminfo tdx field value is zero
+    tdx_meminfo=$(pamt_meminfo_tdx)
+    if [ "$tdx_meminfo" -eq 0 ]; then
+      die "TDX KVM host /proc/meminfo tdx field value is still zero after TDVM launch, \
+      please check host kernel pamt enabling setup."
+    else
+      test_print_trc "TDX KVM host /proc/meminfo tdx field is $tdx_meminfo after TDVM lauched"
+    fi
+    # shutdown TDVM
+    vm_shutdown 10021 || die "Failed to shutdown TDVM"
+    sleep 10
+    # check if TDX KVM host /proc/meminfo tdx field value is zero
+    tdx_meminfo=$(pamt_meminfo_tdx)
+    if [ "$tdx_meminfo" -eq 0 ]; then
+      test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after TDVM shutdown"
+    else
+      die "TDX KVM host /proc/meminfo tdx field value is not zero after TDVM shutdown, \
+      please check host kernel pamt enabling setup."
+    fi
+    # shutdown legacy VM
+    vm_shutdown 10022 || die "Failed to shutdown legacy VM"
+    sleep 10
+    # check if TDX KVM host /proc/meminfo tdx field value is zero
+    tdx_meminfo=$(pamt_meminfo_tdx)
+    if [ "$tdx_meminfo" -eq 0 ]; then
+      test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after legacy VM shutdown"
+    else
+      die "TDX KVM host /proc/meminfo tdx field value is not zero after legacy VM shutdown, \
+      please check host kernel pamt enabling"
+    fi
+    ;;
+  # [stress] TDVM 1 1 VCPU and 1GB MEM, TDVM2 1 VCPU and 96GB, launch and shutdown 10 times, check dpamt accordingly
+  10)
+    tdx_basic_check;
+    pamt_basic_check;
+    # 10 repeat times while loop
+    for i in {1..10}; do
+      test_print_trc "Start TDVM1 and TDVM2 launch and dpamt check, repeat times: $i"
+      # launch TDVM1 with 1 vCPU, 1GB memory and port 10021
+      ./qemu_dpamt.sh 1 1 10021 $GUEST_IMAGE_1 > /dev/null 2>&1 &
+      # launch TDVM2 with 1 vCPU, 96GB memory and port 10022
+      ./qemu_dpamt.sh 1 96 10022 $GUEST_IMAGE_2 > /dev/null 2>&1 &
+      # wait for TDVM1 and TDVM2 to be launched
+      sleep 60
+      # check if TDX KVM host /proc/meminfo tdx field value is zero
+      tdx_meminfo=$(pamt_meminfo_tdx)
+      if [ "$tdx_meminfo" -eq 0 ]; then
+        die "TDX KVM host /proc/meminfo tdx field value is still zero after TDVMs launch, \
+        please check host kernel pamt enabling setup."
+      else
+        test_print_trc "TDX KVM host /proc/meminfo tdx field is $tdx_meminfo after TDVMs lauched"
+      fi
+      # shutdown TDVM1
+      vm_shutdown 10021 || die "Failed to shutdown TDVM1"
+      sleep 10
+      # check if TDX KVM host /proc/meminfo tdx field value is not zero since TDVM2 is still alive
+      tdx_meminfo=$(pamt_meminfo_tdx)
+      if [ "$tdx_meminfo" -eq 0 ]; then
+        die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM1 shutdown"
+      else
+        test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM1 shutdown"
+      fi
+      # shutdown TDVM2
+      vm_shutdown 10022 || die "Failed to shutdown TDVM2"
+      sleep 10
+      # check if TDX KVM host /proc/meminfo tdx field value is zero
+      tdx_meminfo=$(pamt_meminfo_tdx)
+      if [ "$tdx_meminfo" -eq 0 ]; then
+        test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after TDVM2 shutdown"
+      else
+        die "TDX KVM host /proc/meminfo tdx field value is not zero $tdx_meminfo after TDVM2 shutdown, \
+        please check host kernel pamt enabling setup."
+      fi
+    done
+    ;;
+  # [stress] TDVM1 1 VCPU and 1GB MEM, TDVM2 1 VCPU and 4GB MEM, TDVM3 1 VCPU and 8GB MEM
+  # TDVM4 1 VCPU and 32GB MEM, TDVM5 1 VCPU and 96GB MEM, create and shutdown 10 times, check dpamt accordinlgy
+  11)
+    tdx_basic_check;
+    pamt_basic_check;
+    # 10 repeat times while loop
+    for i in {1..10}; do
+      test_print_trc "Start TDVM1, TDVM2, TDVM3, TDVM4 and TDVM5 launch and dpamt check, repeat times: $i"
+      # launch TDVM1 with 1 vCPU, 1GB memory and port 10021
+      ./qemu_dpamt.sh 1 1 10021 $GUEST_IMAGE_1 > /dev/null 2>&1 &
+      # launch TDVM2 with 1 vCPU, 4GB memory and port 10022
+      ./qemu_dpamt.sh 1 4 10022 $GUEST_IMAGE_2 > /dev/null 2>&1 &
+      # launch TDVM3 with 1 vCPU, 8GB memory and port 10023
+      ./qemu_dpamt.sh 1 8 10023 $GUEST_IMAGE_3 > /dev/null 2>&1 &
+      # launch TDVM4 with 1 vCPU, 32GB memory and port 10024
+      ./qemu_dpamt.sh 1 32 10024 $GUEST_IMAGE_4 > /dev/null 2>&1 &
+      # launch TDVM5 with 1 vCPU, 96GB memory and port 10025
+      ./qemu_dpamt.sh 1 96 10025 $GUEST_IMAGE_5 > /dev/null 2>&1 &
+      # wait for all TDVMs to be launched
+      sleep 60
+      # check if TDX KVM host /proc/meminfo tdx field value is zero
+      tdx_meminfo=$(pamt_meminfo_tdx)
+      if [ "$tdx_meminfo" -eq 0 ]; then
+        die "TDX KVM host /proc/meminfo tdx field value is still zero after all TDVMs launch, \
+        please check host kernel pamt enabling setup."
+      else
+        test_print_trc "TDX KVM host /proc/meminfo tdx field is $tdx_meminfo after all TDVMs lauched"
+      fi
+      # shutdown all TDVMs one by one
+      vm_shutdown 10021 || die "Failed to shutdown TDVM1"
+      sleep 10
+      # check if TDX KVM host /proc/meminfo tdx field value is not zero since TDVM2, TDVM3, TDVM4 and TDVM5 are still alive
+      tdx_meminfo=$(pamt_meminfo_tdx)
+      if [ "$tdx_meminfo" -eq 0 ]; then
+        die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM1 shutdown"
+      else
+        test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM1 shutdown"
+      fi
+      vm_shutdown 10022 || die "Failed to shutdown TDVM2"
+      sleep 10
+      tdx_meminfo=$(pamt_meminfo_tdx)
+      if [ "$tdx_meminfo" -eq 0 ]; then
+        die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM2 shutdown"
+      else
+        test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM2 shutdown"
+      fi
+      vm_shutdown 10023 || die "Failed to shutdown TDVM3"
+      sleep 10
+      tdx_meminfo=$(pamt_meminfo_tdx)
+      if [ "$tdx_meminfo" -eq 0 ]; then
+        die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM3 shutdown"
+      else
+        test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM3 shutdown"
+      fi
+      vm_shutdown 10024 || die "Failed to shutdown TDVM4"
+      sleep 10
+      tdx_meminfo=$(pamt_meminfo_tdx)
+      if [ "$tdx_meminfo" -eq 0 ]; then
+        die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM4 shutdown"
+      else
+        test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM4 shutdown"
+      fi
+      vm_shutdown 10025 || die "Failed to shutdown TDVM5"
+      sleep 10
+      # check if TDX KVM host /proc/meminfo tdx field value is zero
+      tdx_meminfo=$(pamt_meminfo_tdx)
+      if [ "$tdx_meminfo" -eq 0 ]; then
+        test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after all TDVMs shutdown"
+      else
+        die "TDX KVM host /proc/meminfo tdx field value is not zero $tdx_meminfo after all TDVMs shutdown, \
+        please check host kernel pamt enabling setup."
+      fi
+    done
+    ;;
+  # [stress] TDVM 1 1 VCPU and 1GB MEM, TDVM2 1 VCPU and 96GB, launch and shutdown 100 cycles, check dpamt accordingly
+  12)
+    tdx_basic_check;
+    pamt_basic_check;
+    # 100 repeat times while loop
+    for i in {1..100}; do
+      test_print_trc "Start TDVM1 and TDVM2 launch and dpamt check, repeat times: $i"
+      # launch TDVM1 with 1 vCPU, 1GB memory and port 10021
+      ./qemu_dpamt.sh 1 1 10021 $GUEST_IMAGE_1 > /dev/null 2>&1 &
+      # launch TDVM2 with 1 vCPU, 96GB memory and port 10022
+      ./qemu_dpamt.sh 1 96 10022 $GUEST_IMAGE_2 > /dev/null 2>&1 &
+      # wait for TDVM1 and TDVM2 to be launched
+      sleep 60
+      # check if TDX KVM host /proc/meminfo tdx field value is zero
+      tdx_meminfo=$(pamt_meminfo_tdx)
+      if [ "$tdx_meminfo" -eq 0 ]; then
+        die "TDX KVM host /proc/meminfo tdx field value is still zero after TDVMs launch, \
+        please check host kernel pamt enabling setup."
+      else
+        test_print_trc "TDX KVM host /proc/meminfo tdx field is $tdx_meminfo after TDVMs lauched"
+      fi
+      # shutdown TDVM1
+      vm_shutdown 10021 || pkill td_pamt_10021 || die "Failed to shutdown TDVM1"
+      sleep 10
+      # check if TDX KVM host /proc/meminfo tdx field value is not zero since TDVM2 is still alive
+      tdx_meminfo=$(pamt_meminfo_tdx)
+      if [ "$tdx_meminfo" -eq 0 ]; then
+        die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM1 shutdown"
+      else
+        test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM1 shutdown"
+      fi
+      # shutdown TDVM2
+      vm_shutdown 10022 || pkill td_pamt_10022 || die "Failed to shutdown TDVM2"
+      sleep 10
+      # check if TDX KVM host /proc/meminfo
+      tdx_meminfo=$(pamt_meminfo_tdx)
+      if [ "$tdx_meminfo" -eq 0 ]; then
+        test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after TDVM2 shutdown"
+      else
+        die "TDX KVM host /proc/meminfo tdx field value is not zero $tdx_meminfo after TDVM2 shutdown, \
+        please check host kernel pamt enabling setup."
+      fi
+    done
+    ;;
+  # [stress] TDVM1 1 VCPU and 1GB MEM, TDVM2 1 VCPU and 4GB MEM, TDVM3 1 VCPU and 8GB MEM
+  # TDVM4 1 VCPU and 32GB MEM, TDVM5 1 VCPU and 96GB MEM, create and shutdown 100 cycles, check dpamt accordinlgy
+  13)
+    tdx_basic_check;
+    pamt_basic_check;
+    # 100 repeat times while loop
+    for i in {1..100}; do
+      test_print_trc "Start TDVM1, TDVM2, TDVM3, TDVM4 and TDVM5 launch and dpamt check, repeat times: $i"
+      # launch TDVM1 with 1 vCPU, 1GB memory and port 10021
+      ./qemu_dpamt.sh 1 1 10021 $GUEST_IMAGE_1 > /dev/null 2>&1 &
+      # launch TDVM2 with 1 vCPU, 4GB memory and port 10022
+      ./qemu_dpamt.sh 1 4 10022 $GUEST_IMAGE_2 > /dev/null 2>&1 &
+      # launch TDVM3 with 1 vCPU, 8GB memory and port 10023
+      ./qemu_dpamt.sh 1 8 10023 $GUEST_IMAGE_3 > /dev/null 2>&1 &
+      # launch TDVM4 with 1 vCPU, 32GB memory and port 10024
+      ./qemu_dpamt.sh 1 32 10024 $GUEST_IMAGE_4 > /dev/null 2>&1 &
+      # launch TDVM5 with 1 vCPU, 96GB memory and port 10025
+      ./qemu_dpamt.sh 1 96 10025 $GUEST_IMAGE_5 > /dev/null 2>&1 &
+      # wait for all TDVMs to be launched
+      sleep 60
+      # check if TDX KVM host /proc/meminfo tdx field value is zero
+      tdx_meminfo=$(pamt_meminfo_tdx)
+      if [ "$tdx_meminfo" -eq 0 ]; then
+        die "TDX KVM host /proc/meminfo tdx field value is still zero after all TDVMs launch, \
+        please check host kernel pamt enabling setup."
+      else
+        test_print_trc "TDX KVM host /proc/meminfo tdx field is $tdx_meminfo after all TDVMs lauched"
+      fi
+      # shutdown all TDVMs one by one
+      vm_shutdown 10021 || pkill td_pamt_10021 || die "Failed to shutdown TDVM1"
+      sleep 10
+      # check if TDX KVM host /proc/meminfo tdx field value is not zero since TDVM2, TDVM3, TDVM4 and TDVM5 are still alive
+      tdx_meminfo=$(pamt_meminfo_tdx)
+      if [ "$tdx_meminfo" -eq 0 ]; then
+        die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM1 shutdown"
+      else
+        test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM1 shutdown"
+      fi
+      vm_shutdown 10022 || pkill td_pamt_10022 || die "Failed to shutdown TDVM2"
+      sleep 10
+      tdx_meminfo=$(pamt_meminfo_tdx)
+      if [ "$tdx_meminfo" -eq 0 ]; then
+        die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM2 shutdown"
+      else
+        test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM2 shutdown"
+      fi
+      vm_shutdown 10023 || pkill td_pamt_10023 || die "Failed to shutdown TDVM3"
+      sleep 10
+      tdx_meminfo=$(pamt_meminfo_tdx)
+      if [ "$tdx_meminfo" -eq 0 ]; then
+        die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM3 shutdown"
+      else
+        test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM3 shutdown"
+      fi
+      vm_shutdown 10024 || pkill td_pamt_10024 || die "Failed to shutdown TDVM4"
+      sleep 10
+      tdx_meminfo=$(pamt_meminfo_tdx)
+      if [ "$tdx_meminfo" -eq 0 ]; then
+        die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM4 shutdown"
+      else
+        test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM4 shutdown"
+      fi
+      vm_shutdown 10025 || pkill td_pamt_10025 || die "Failed to shutdown TDVM5"
+      sleep 10
+      # check if TDX KVM host /proc/meminfo tdx field value is zero
+      tdx_meminfo=$(pamt_meminfo_tdx)
+      if [ "$tdx_meminfo" -eq 0 ]; then
+        test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after all TDVMs shutdown"
+      else
+        die "TDX KVM host /proc/meminfo tdx field value is not zero $tdx_meminfo after all TDVMs shutdown, \
+        please check host kernel pamt enabling setup."
+      fi
+    done
+    ;;
+  *)
+    test_print_err "Invalid testcase number: $TESTCASE"
+    usage && exit 1
+    ;;
+esac
+# end of script

--- a/BM/tdx-host/tests
+++ b/BM/tdx-host/tests
@@ -1,0 +1,38 @@
+# This file collects TDX KVM dynamic pamt tests on
+# Intel® Architecture-based platforms.
+# @hw_dep: ../tdx-guest/tdx_dep_check.sh -t hw_dep_check @SEAMRR not enabled, probably HW or BIOS can't support TDX
+# @other_dep: general_test.sh -t kconfig -k "CONFIG_INTEL_TDX_HOST=y"
+######## TDX Host Kernel module kvm_intel TDX enabling status check
+# @other_dep: tdx_dep_check.sh -t other_dep_check1 @host kernel kvm_intel has no TDX enabled
+
+# case implemented by tdx_dpamt_test.sh
+# case info: basic KVM host TDX enabling check
+./tdx-host/tdx_dpamt_test.sh -t 0
+# case info: basic KVM host dynamic pamt check
+./tdx-host/tdx_dpamt_test.sh -t 1
+# case info: 1 TDVM of 1 VCPU and 1GB MEM launch & shutdown, with dpamt check
+./tdx-host/tdx_dpamt_test.sh -t 2
+# case info: 1 TDVM of 1 VCPU and 4GB MEM launch & shutdown, with dpamt check
+./tdx-host/tdx_dpamt_test.sh -t 3
+# case info: 1 TDVM of 1 VCPU and 96GB MEM launch & shutdown, with dpamt check
+./tdx-host/tdx_dpamt_test.sh -t 4
+# case info: 2 TDVMs of 1 VCPU and 1GB MEM launch & shutdown, with dpamt check
+./tdx-host/tdx_dpamt_test.sh -t 5
+# case info: 2 TDVMs of 1 VCPU and 4GB MEM launch & shutdown, with dpamt check
+./tdx-host/tdx_dpamt_test.sh -t 6
+# case info: 2 TDVMs of 1 VCPU and 96GB MEM launch & shutdown, with dpamt check
+./tdx-host/tdx_dpamt_test.sh -t 7
+# case info: [negative] 1 VPCU and 1GB MEM legacy VM launch and dpamt check
+./tdx-host/tdx_dpamt_test.sh -t 8
+# case info: [negative] 1 VCPU and 1GB TDVM and legacy VM launch and dpamt check
+./tdx-host/tdx_dpamt_test.sh -t 9
+# case info: [stress] TDVM 1 1 VCPU and 1GB MEM, TDVM2 1 VCPU and 96GB, launch and shutdown 10 times, check dpamt accordingly
+./tdx-host/tdx_dpamt_test.sh -t 10
+# case info: [stress] TDVM 1 1 VCPU and 1GB MEM, TDVM2 1 VCPU and 96GB, launch and shutdown 10 times, check dpamt accordingly
+# TDVM4 1 VCPU and 32GB MEM, TDVM5 1 VCPU and 96GB MEM, create and shutdown 10 times, check dpamt accordinlgy
+./tdx-host/tdx_dpamt_test.sh -t 11
+# case info: [stress] TDVM 1 1 VCPU and 1GB MEM, TDVM2 1 VCPU and 96GB, launch and shutdown 100 cycles, check dpamt accordingly
+./tdx-host/tdx_dpamt_test.sh -t 12
+# case info: [stress] TDVM1 1 VCPU and 1GB MEM, TDVM2 1 VCPU and 4GB MEM, TDVM3 1 VCPU and 8GB MEM
+# TDVM4 1 VCPU and 32GB MEM, TDVM5 1 VCPU and 96GB MEM, create and shutdown 100 cycles, check dpamt accordinlgy
+./tdx-host/tdx_dpamt_test.sh -t 13


### PR DESCRIPTION
TDX dynamic pamt is a new TDX feature to support VMM to allocate PAMT_4K dynamically when there is TDVM launched, and reclaim all pages in a contiguous area when TDVM is gone, to reduce static PAMT 4K pages allocation consumption on system memory.

This test implementation cover all functional and stress testing of dynamic pamt allocation implemented in current Linux Kernel RFC patch series https://lore.kernel.org/all/20250609191340.2051741-1-kirill.shutemov@linux.intel.com/