### PR TITLE
tdx-compliance: Fix kernel Call Trace about check_preemption

### DIFF
--- a/BM/tdx-compliance/tdx-compliance-main.c
+++ b/BM/tdx-compliance/tdx-compliance-main.c
@@ -325,9 +325,9 @@ static int run_all_cpuid(void)
 		}
 		if (kretprobe_switch)
 			pr_info("leaf:%X subleaf:%X\n", t->leaf, t->subleaf);
-
+		preempt_disable();
 		run_cpuid(t);
-
+		preempt_enable();
 		t->ret = check_results_cpuid(t);
 		if (t->ret == 1)
 			stat_pass++;


### PR DESCRIPTION
When run tdx compliance CPUID cases, if with CONFIG_DEBUG_PREEMPT set in kernel config, guest Call Trace:
[  161.254208] Call Trace:
[  161.254211]  <TASK>
[  161.254214]  dump_stack_lvl+0x4b/0x70
[  161.254218]  check_preemption_disabled+0xd6/0xe0 [  161.254223]  run_cpuid.isra.0+0x11/0x70 [tdx_compliance] [  161.254227]  run_all_cpuid.isra.0+0xf7/0x1b9 [tdx_compliance] [  161.254229]  tdx_tests_proc_write.cold+0xa7/0x107 [tdx_compliance] [  161.254231]  full_proxy_write+0x59/0xa0
[  161.254236]  vfs_write+0xea/0x440
[  161.254239]  ? preempt_count_add+0x4b/0xa0
[  161.254242]  ? fput+0x34/0x190
[  161.254243]  ? filp_close+0x1d/0x30
[  161.254246]  ? do_dup2+0xae/0x150
[  161.254249]  ksys_write+0x6a/0xe0
[  161.254251]  do_syscall_64+0x54/0x110
[  161.254254]  entry_SYSCALL_64_after_hwframe+0x77/0x7f [  161.254257] RIP: 0033:0x7f20de585e14

Disable check_preemption before run cpuid and restore after the test.