### PR TITLE
BM: performance: Fix performance

### DIFF
--- a/BM/performance/perf_bench.py
+++ b/BM/performance/perf_bench.py
@@ -163,7 +163,7 @@ def run_perf_bench(bench_feature, feature_option):
         exit_code = result.run()
         if exit_code != 0:
             print("Perf benchmark failed")
-            return exit_code
+            sys.exit(1)
 
     except Exception as e:
         print(f"Error running perf bench: {e}")

--- a/BM/performance/tests
+++ b/BM/performance/tests
@@ -21,7 +21,7 @@ python3 -u perf_bench.py --bench_feature syscall --feature_option getpgid
 # fork: benchmark for fork(2) calls
 python3 -u perf_bench.py --bench_feature syscall --feature_option fork
 # execve: benchmark for execve(2) calls
-python3 -u perf_bench.py --bench_feature syscall --feature_option evecve
+python3 -u perf_bench.py --bench_feature syscall --feature_option execve
 # synthesize: benchmark perf event synthesis
 python3 -u perf_bench.py --bench_feature internals --feature_option synthesize
 # kallsyms-parse: benchmark kallsyms parsing


### PR DESCRIPTION
This fixes the following problems in performance check:

1) Repalce evecve with execve.

2) When perf bench fails, the error code returned by using "return" cannot be captured by runtest.py. As a result, runtest.py will still assume that the performance tests executed successfully. Therefore, "exit" should be used to return an exit code.