### PR TITLE
BM/ras: remove yum install step

### DIFF
--- a/BM/ras/README.md
+++ b/BM/ras/README.md
@@ -6,9 +6,15 @@ Current BM/ras covers following features:
 * basic error injection
 
 ## Usage
-Before test case execution, make sure git submodules are initialized and updated:
+Before test case execution:
+1. make sure git submodules are initialized and updated:
 ```
 git submodule update --init --recursive
+```
+2. make sure required packages are installed:
+```
+yum install msr-tools cpuid mcelog screen # for CentOS
+apt install msr-tools cpuid mcelog screen # for Debian/Ubuntu
 ```
 
 You can run the cases one by one, e.g. command

--- a/BM/ras/lmce_test.sh
+++ b/BM/ras/lmce_test.sh
@@ -120,6 +120,5 @@ while getopts :t:H arg; do
 done
 
 lmce_support_check # check whether LMCE feature is supported
-pkg_check_install msr-tools cpuid mcelog # install pre-requisite packages
 mcelog_config # configure mcelog service
 lmce_test

--- a/BM/ras/mce_test.sh
+++ b/BM/ras/mce_test.sh
@@ -93,5 +93,4 @@ while getopts :t:H arg; do
   esac
 done
 
-pkg_check_install screen
 mce_test

--- a/BM/ras/ras_common.sh
+++ b/BM/ras/ras_common.sh
@@ -11,21 +11,6 @@ MCELOG_LOGFILE=/var/log/mcelog
 MCA_BANK_NUM=$((0x$(rdmsr 0x179) & 0xFF)) # 0x179 is IA32_MCG_CAP
 IA32_MCi_CTL2=$(rdmsr 0x280) # 0x280 is IA32_MCi_CTL2
 
-# check whether one package is installed, if not, install the package
-# Usage: pkg_check_install pkg_name_1 pkg_name_2 pkg_name_x
-pkg_check_install() {
-  for pkg_name in "$@"; do
-    if ! rpm -q $pkg_name &> /dev/null; then
-      test_print_trc "${pkg_name} is not installed. Installing now."
-      if ! yum install -y $pkg_name; then
-        die "Failed to install ${pkg_name}"
-      fi
-    else
-      test_print_trc "${pkg_name} is already installed"
-    fi
-  done
-}
-
 # check mcelog service is properly configured and running
 mcelog_config() {
   local daemon=0


### PR DESCRIPTION
Assuming case execution OS to be CentOS is not a compatible method. Add required package information into README and remove related package installation step from test script.