### PR TITLE
update default compile target and tests contents

### DIFF
--- a/BM/amx/Makefile
+++ b/BM/amx/Makefile
@@ -5,11 +5,11 @@ CC = gcc
 BIN_AMX = tmul
 CFILES_AMX = tmul.c
 
-all: CFLAG += -g -DFP16 -static
-all: spr
-
-spr:
+all:
 	$(CC) $(CFLAG) $(CFILES_AMX) -o $(BIN_AMX) $(LIBS)
+
+fp16: CFLAG += -g -DFP16
+fp16: all
 
 clean:
 	-rm $(BIN_AMX)

--- a/BM/amx/README.md
+++ b/BM/amx/README.md
@@ -24,8 +24,8 @@ It will be checked if the result is correct or not.
 
     To compile,
     for amx_bf16, amx_int8 test:  
-    $ make
-    for extra amx_fp16 test:
+    $ make  
+    for extra amx_fp16 test:  
     $ make fp16
 
     To clean,  

--- a/BM/amx/tests
+++ b/BM/amx/tests
@@ -18,7 +18,7 @@
 #      5: break by futex
 #  -t, --thread-count [Should not be less than 1]
 #  -c, --cycle-number [Should not be less than 1]
-#  -i, --instruction-type [0:TDPBF16PS 1:TDPBSSD 2:TDPBSUD 3:TDPBUSD 4:TDPBUUD 5:TDPFP16PS]
+#  -i, --instruction-type [0:TDPBF16PS 1:TDPBSSD 2:TDPBSUD 3:TDPBUSD 4:TDPBUUD]
 
 # functional tests
 tmul -b 0 -t 10 -c 10 -i 0
@@ -46,4 +46,3 @@ tmul -b 1 -t 10 -c 10 -i 4
 tmul -b 2 -t 10 -c 10 -i 4
 tmul -b 3 -t 10 -c 10 -i 4
 tmul -b 5 -t 10 -c 10 -i 4
-# amx_fp16 instruction based tests

--- a/BM/amx/tests-stress
+++ b/BM/amx/tests-stress
@@ -18,21 +18,18 @@
 #      5: break by futex
 #  -t, --thread-count [Should not be less than 1]
 #  -c, --cycle-number [Should not be less than 1]
-#  -i, --instruction-type [0:TDPBF16PS 1:TDPBSSD 2:TDPBSUD 3:TDPBUSD 4:TDPBUUD 5:TDPFP16PS]
+#  -i, --instruction-type [0:TDPBF16PS 1:TDPBSSD 2:TDPBSUD 3:TDPBUSD 4:TDPBUUD]
 
+# stress tests on cycles
 tmul -b 4 -t 10 -c 100000 -i 0
 tmul -b 4 -t 10 -c 100000 -i 1
 tmul -b 4 -t 10 -c 100000 -i 2
 tmul -b 4 -t 10 -c 100000 -i 3
 tmul -b 4 -t 10 -c 100000 -i 4
-# amx_fp16 instruction based tests
-tmul -b 4 -t 10 -c 100000 -i 5
 
-# stress tests
+# stress tests on threads
 tmul -b 1 -t 10000 -c 10 -i 0
 tmul -b 1 -t 10000 -c 10 -i 1
 tmul -b 1 -t 10000 -c 10 -i 2
 tmul -b 1 -t 10000 -c 10 -i 3
 tmul -b 1 -t 10000 -c 10 -i 4
-# amx_fp16 instruction based tests
-tmul -b 1 -t 10000 -c 10 -i 5


### PR DESCRIPTION
update default compile target to adapt to different gcc version, update tests contents accordingly