### PR TITLE
KVM: move smp parameter definition to tdx_cpuoff_pinedVMdown.cfg

### DIFF
--- a/KVM/qemu/tdx_cpuoff_pinedVMdown.cfg
+++ b/KVM/qemu/tdx_cpuoff_pinedVMdown.cfg
@@ -4,6 +4,7 @@
     machine_type_extra_params = "kernel-irqchip=split"
     vm_secure_guest_type = tdx
     # Don't create/remove guest images
+    smp = 64
     start_vm = no
     # Stop VM after testing
     kill_vm = yes

--- a/KVM/qemu/tests/tdx_cpuoff_pinedVMdown.py
+++ b/KVM/qemu/tests/tdx_cpuoff_pinedVMdown.py
@@ -31,7 +31,6 @@ def run(test, params, env):
     # TD can not boot up with vCPU number larger than host pCPU
     if cpu.online_count() < 64:
         test.cancel("Platform doesn't support to run this test")
-    params["smp"] = 64
 
     for i in range(0, 20):
         params["start_vm"] = "yes"


### PR DESCRIPTION
It turns out that a newline should be appended to the config file when editing in vscode in windows, or it will cause case matching chaos.