### PR TITLE
KVM: update TDX module initialization info

### DIFF
--- a/KVM/qemu/tdx_seam_module.cfg
+++ b/KVM/qemu/tdx_seam_module.cfg
@@ -16,5 +16,5 @@
     cpu_model = host
     read_cmd = "cat /sys/module/kvm_intel/parameters/%s"
     rdmsr_cmd = "rdmsr 0xfe --bitfield 15:15"
-    tdx_module_pattern = "tdx: module initialized"
+    tdx_module_pattern = "tdx: TDX-Module initialized"
     tdx_negative_pattern = "No TDX module loaded by BIOS"


### PR DESCRIPTION
TDX module initialization info changed from "tdx: module initialized"
to "tdx: TDX-Module initialized" from upstream kernel 7.1