### PR TITLE
BM/FRED: Remove kernel cmdline fred=on check and dmesg check

### DIFF
--- a/BM/fred/fred_test.sh
+++ b/BM/fred/fred_test.sh
@@ -30,18 +30,11 @@ kconfig_test() {
 # $1: Parameter should be support in cpuinfo
 # Return: 0 for true, otherwise false
 cpu_info_check() {
-  do_cmd "grep -q 'fred=on' '/proc/cmdline'"
   local cpu_func=$1
   [ -n "$cpu_func" ] || die "cpu info check name is null:$cpu_func"
   grep -q "$cpu_func" /proc/cpuinfo || block_test "CPU not support:$cpu_func"
   test_print_trc "/proc/cpuinfo contain '$cpu_func'"
   return 0
-}
-
-# Dmesg test: Verify if FRED is initialized
-dmesg_test() {
-  do_cmd "grep -q 'fred=on' '/proc/cmdline'"
-  do_cmd "dmesg | grep 'Initialize FRED on CPU'"
 }
 
 # CPUID test: Check FRED CPUID
@@ -65,9 +58,6 @@ fred_test() {
   case $TEST_SCENARIO in
     kconfig)
       kconfig_test
-      ;;
-    dmesg)
-      dmesg_test
       ;;
     cpuid)
       cpuid_test

--- a/BM/fred/tests
+++ b/BM/fred/tests
@@ -2,7 +2,6 @@
 # @hw_dep: cpuid_check 7 0 1 0 a 17 @ CPU doesn't support FRED CPUID.(EAX=07H,ECX=01H):EAX[bit 17]
 # @other_dep: general_test.sh -t kconfig -k "CONFIG_X86_FRED=y" @ No kconfig CONFIG_X86_FRED=y
 fred_test.sh -t kconfig
-fred_test.sh -t dmesg
 fred_test.sh -t cpuid
 fred_test.sh -t cpuinfo
 fred_test.sh -t lkgs

--- a/BM/nmis/nmis_test.sh
+++ b/BM/nmis/nmis_test.sh
@@ -24,8 +24,6 @@ nmi_enable_test() {
   do_cmd "cpuid_check 7 0 1 0 a 17"
   #CPUID.0x7.1.EAX[20] == 1
   do_cmd "cpuid_check 7 0 1 0 a 20"
-  do_cmd "grep -q 'fred=on' '/proc/cmdline'"
-  full_dmesg_check "contain" "Initialize FRED on CPU"
   full_dmesg_check "null" "NMI without source information! Disable source reporting."
 }
 


### PR DESCRIPTION
From kernel 7.1-rc1, FRED is enabled by default only if CONFIG_X86_FRED=y in Kconfig, no need to add fred=on in kernel cmdline, and FRED initialization info is removed from dmesg either.


(cherry picked from commit 91f35fc76e7fa213ca45b9cccfbd076ed87b1d7e)