### PR TITLE
BM/pstate: Fix balance_performance EPP check on EMR

### DIFF
--- a/BM/pstate/intel_pstate_tests.sh
+++ b/BM/pstate/intel_pstate_tests.sh
@@ -832,9 +832,9 @@ check_epp_req() {
   performance)
     epp_req=0
     ;;
-  # SPR will use 32 for balance_performance EPP value
+  # SPR and EMR will use 32 for balance_performance EPP value
   balance_performance)
-    if [ "$cpu_model" == 143 ]; then
+    if [ "$cpu_model" == 143 ] || [ "$cpu_model" == 207 ]; then
       epp_req=32
     else
       epp_req=128

--- a/BM/pstate/intel_pstate_tests.sh
+++ b/BM/pstate/intel_pstate_tests.sh
@@ -22,8 +22,10 @@ CPU_CPUFREQ_ATTR="affected_cpus cpuinfo_max_freq cpuinfo_min_freq
   scaling_min_freq scaling_setspeed"
 DEFAULT_SCALING_GOV=$(cat $CPU_SYSFS_PATH/cpu0/cpufreq/scaling_governor)
 
-readonly no_turbo_value=$(cat "$CPU_NO_TURBO_NODE")
-readonly pstate_status_value=$(cat "$CPU_PSTATE_SYSFS_PATH/status")
+no_turbo_value=$(cat "$CPU_NO_TURBO_NODE")
+readonly no_turbo_value
+pstate_status_value=$(cat "$CPU_PSTATE_SYSFS_PATH/status")
+readonly pstate_status_value
 
 # rdmsr tool is required to run pstate cases
 if which rdmsr 1>/dev/null 2>&1; then
@@ -65,7 +67,7 @@ pstate_teardown() {
     local online_cpu=""
 
     online_cpu=$(ls /sys/devices/system/cpu/cpu*/online | wc -l)
-    online_cpu=$(($online_cpu+1))
+    online_cpu=$((online_cpu+1))
     test_print_trc "Total CPUs from /sys/devices/: $online_cpu"
 
     # Hot plug all logic CPUs except cpu0
@@ -1129,5 +1131,6 @@ intel_pstate_test() {
 }
 
 intel_pstate_test
+# shellcheck disable=SC2034 # consumed by exec_teardown from test framework
 teardown_handler="pstate_teardown"
 exec_teardown


### PR DESCRIPTION
## Summary

`intel_pstate_tests08` verifies the EPP request value after setting
`energy_performance_preference` to `balance_performance`.

The test currently expects EPP value `32` only on Sapphire Rapids
(model 143).  On Emerald Rapids (model 207), it falls back to the legacy
expected value `128`, but the current kernel behavior is to use `32`.

The upstream Linux change 64a66f4a3c89 ("cpufreq: intel_pstate: Update
Balance performance EPP for Emerald Rapids") changed Emerald Rapids to
use the same `balance_performance` EPP value as Sapphire Rapids.

Update the LKVS expectation for model 207 to match the kernel behavior.

## Validation

I have done:
- `git diff --check origin/main..HEAD`
- `bash -n BM/pstate/intel_pstate_tests.sh`
- `scripts/checkpatch.pl --strict 0001-BM-pstate-Fix-balance_performance-EPP-check-on-EMR.patch`
- Ran `./intel_pstate_tests.sh -t verify_gov_powersave_epp_balance_perf`
  on an Emerald Rapids system, model 207. Passed.

The EMR run reported CPU model 207, read EPP value `32`, and completed
with `check_epp_req PASS`.

Signed-off-by: Yijia Wang <wangyijia.yeah@bytedance.com>