### PR TITLE
BM: update Dynamic PAMT memory accounting

### DIFF
--- a/BM/tdx-host/tdx_dpamt_test.sh
+++ b/BM/tdx-host/tdx_dpamt_test.sh
@@ -5,7 +5,7 @@
 # Author:   Hongyu Ning <hongyu.ning@intel.com>
 # History:  10, Jun., 2025 - Hongyu Ning - creation
 
-# @desc This script is top level TDX KVM host dynamic pamt test
+# @desc This script is top level TDX host dynamic pamt test
 # @functions provided:
 #  #   - basic pamt prerequisites check
 #  #   - launch TDVM or legacy VM
@@ -36,53 +36,148 @@ usage() {
 EOF
 }
 
-# function to do basic TDX KVM host enabling check
+# function to do basic TDX host enabling check
 tdx_basic_check(){
-  #check if TDX KVM host is booted with TDX enabled
-  dmesg | grep -i "tdx" | grep -iq "module initialized" || \
-  die "TDX KVM host not booted with TDX enabled, \
+  #check if TDX host is booted with TDX enabled
+  dmesg | grep -i "tdx" | grep -i "module" | grep -iq "initialized" || \
+  die "TDX host not booted with TDX enabled, \
   please check host kernel tdx enabling setup."
   test_print_trc "TDX module initialized correctly"
-  #check if TDX KVM host is booted with TDX enabled
+  #check if TDX host is booted with TDX enabled
   if [ "$(cat /sys/module/kvm_intel/parameters/tdx)" = "Y" ]; then
-    test_print_trc "TDX KVM host booted with TDX enabled"
+    test_print_trc "TDX host booted with TDX enabled"
   else
-    die "TDX KVM host not booted with TDX enabled, \
+    die "TDX host not booted with TDX enabled, \
     please check host kernel tdx enabling setup."
   fi
 }
 
-# function to do basic TDX KVM host dynamic pamt check
+# function to do basic TDX host dynamic pamt check
 pamt_basic_check() {
-  # check if TDX KVM host is booted with pamt enabled
-  dmesg | grep -i "tdx" | grep -iq "enable dynamic pamt" || \
-  die "TDX KVM host not booted with dynamic pamt enabled, \
+  # check if TDX host is booted with pamt enabled
+  dmesg | grep -i "tdx" | grep -i "enable" | grep -i "dynamic" | grep -iq "pamt" || \
+  die "TDX host not booted with dynamic pamt enabled, \
   please check host kernel pamt enabling setup."
-  test_print_trc "TDX KVM host booted with dynamic pamt enabled" 
-  # check /proc/meminfo TDX field exists and value is zero
-  grep -iq "tdx" /proc/meminfo || \
-  die "TDX KVM host not booted with /proc/meminfo tdx field, \
-  please check host kernel tdx enabling setup."
-  local tdx_meminfo
-  tdx_meminfo=$(grep -i "tdx:" /proc/meminfo | awk '{print $2}')
-  if [ "$tdx_meminfo" -eq 0 ]; then
-    test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero"
-  else
-    die "TDX KVM host /proc/meminfo tdx field value is not zero, \
-    please check host kernel pamt enabling setup."
+  test_print_trc "TDX host booted with dynamic pamt enabled"
+  if [ "$TESTCASE" -ge 2 ] && [ "$TESTCASE" -le 13 ]; then
+    # check dynamic PAMT usage is zero before launching TDX guests
+    local dpamt_kb
+    dpamt_kb=$(get_dpamt_kb)
+    if [ "$dpamt_kb" -eq 0 ]; then
+      test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests is zero"
+    else
+      die "TDX host Dynamic PAMT memory usage for KVM TDX guests is NOT zero, \
+      please check host kernel pamt enabling setup."
+    fi
   fi
 }
 
-# functiont to check and return pamt value in /proc/meminfo
-pamt_meminfo_tdx(){
-  local tdx_meminfo
-  tdx_meminfo=$(grep -i "tdx:" /proc/meminfo | awk '{print $2}')
-  if [ -z "$tdx_meminfo" ]; then
-    die "TDX KVM host /proc/meminfo tdx field not found, \
-    please check host kernel pamt enabling setup."
-  else
-    echo "$tdx_meminfo"
+# function to return dynamic PAMT usage in KB
+#
+# This function performs a basic validation of TDX host Dynamic PAMT behavior
+# during the lifecycle of a KVM TDX guest.
+#
+# The check uses the ftrace function profiler to count calls to:
+#   - tdh_phymem_pamt_add()
+#   - tdh_phymem_pamt_remove()
+#
+# In the current Dynamic PAMT implementation, each active Dynamic PAMT region
+# covers one 2MB-aligned host physical address range and uses two 4KB backing
+# pages. Therefore, the estimated Dynamic PAMT memory usage is calculated as:
+#
+#   Dynamic PAMT usage (KB)
+#     = (PAMT.ADD calls - PAMT.REMOVE calls) * 8
+#
+# where:
+#   - one tdh_phymem_pamt_add() call represents adding 8KB of Dynamic PAMT
+#     backing memory for a 2MB host physical memory region;
+#   - one tdh_phymem_pamt_remove() call represents releasing the corresponding
+#     8KB of Dynamic PAMT backing memory.
+#
+# The basic test flow is:
+#
+#   1. Enable the ftrace function profiler and start with a clean profiling
+#      window.
+#   2. Record the baseline Dynamic PAMT usage before creating the TDX guest.
+#   3. Create and boot a KVM TDX guest.
+#   4. Verify that Dynamic PAMT usage increases after the TDX guest is created
+#      and private memory is populated.
+#   5. Destroy the TDX guest and wait until the VM process exits completely.
+#   6. Verify that Dynamic PAMT usage returns to the original baseline,
+#      indicating that the Dynamic PAMT backing pages were reclaimed.
+#
+# This is intended as a lightweight functional check and as a replacement for
+# the previous /proc/meminfo TDX memory counter that was removed from the
+# Dynamic PAMT patch series in upstream.
+#
+# Note:
+#   The ftrace function profiler counts function invocations rather than the
+#   return status of the underlying TDH.PHYMEM.PAMT.ADD/REMOVE operations.
+#   Therefore, the calculation assumes the normal successful execution path.
+#   Dynamic PAMT-related kernel warnings or errors will be checked separately
+#   in dmesg and treated as test failures by dpamt_dmesg_check function.
+#
+get_dpamt_kb() {
+  local trace=/sys/kernel/tracing
+  local add remove
+
+  add=$(awk '
+    /tdh_phymem_pamt_add/ {
+      n += $2
+    }
+    END {
+      print n+0
+    }
+  ' "$trace"/trace_stat/function*)
+
+  remove=$(awk '
+    /tdh_phymem_pamt_remove/ {
+      n += $2
+    }
+    END {
+      print n+0
+    }
+  ' "$trace"/trace_stat/function*)
+
+  echo $(( (add - remove) * 8 ))
+}
+
+# function to start function profiling for a testcase
+dpamt_profile_start() {
+  local profile=/sys/kernel/tracing/function_profile_enabled
+
+  if [ ! -w "$profile" ]; then
+    die "Function profiler control $profile is not writable."
   fi
+
+  echo 0 > "$profile" || die "Failed to reset function profiling."
+  echo 1 > "$profile" || die "Failed to enable function profiling."
+  trap dpamt_profile_stop EXIT
+  test_print_trc "Function profiling enabled for dynamic PAMT accounting"
+}
+
+# function to stop function profiling for a testcase
+dpamt_profile_stop() {
+  local profile=/sys/kernel/tracing/function_profile_enabled
+
+  if [ -w "$profile" ] && [ "$(cat "$profile")" = "1" ]; then
+    echo 0 > "$profile"
+    test_print_trc "Function profiling disabled for dynamic PAMT accounting"
+  fi
+}
+
+# function to check dynamic PAMT failures in the kernel log
+dpamt_dmesg_check() {
+  local dmesg_error
+
+  dmesg_error=$(dmesg | grep -iE \
+    'tdx_pamt_(get|put)|tdh_phymem_pamt_(add|remove)|KVM.*BUG|TDX.*(fail|error)|PAMT.*(fail|error)')
+  if [ -n "$dmesg_error" ]; then
+    test_print_err "$dmesg_error"
+    die "Dynamic PAMT related failure found in dmesg."
+  fi
+
+  test_print_trc "No dynamic PAMT related failure found in dmesg"
 }
 
 # function to shutdown TDVM or legacy VM with port number passed in
@@ -165,6 +260,15 @@ while getopts :t:h arg; do
   esac
 done
 
+if [ -z "$TESTCASE" ] || [[ "$TESTCASE" == *[!0-9]* ]]; then
+  test_print_err "Invalid testcase number: $TESTCASE"
+  usage && exit 1
+fi
+
+if [ "$TESTCASE" -ge 2 ] && [ "$TESTCASE" -le 13 ]; then
+  dpamt_profile_start
+fi
+
 case $TESTCASE in
   # basic KVM host TDX enabling check
   0)
@@ -186,23 +290,23 @@ case $TESTCASE in
     test_print_trc "tdvm 1 launched, VM boot log at /tmp/tdpamt_2/tdvm.1.log"
     # wait for TDVM fully launched for ssh accessible
     vm_up_check 10021
-    # check if TDX KVM host /proc/meminfo tdx field value is zero
-    tdx_meminfo=$(pamt_meminfo_tdx)
+    # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero
+    tdx_meminfo=$(get_dpamt_kb)
     if [ "$tdx_meminfo" -eq 0 ]; then
-      die "TDX KVM host /proc/meminfo tdx field value is still zero after TDVM launch, \
+      die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is still zero after TDVM launch, \
       please check host kernel pamt enabling setup."
     else
-      test_print_trc "TDX KVM host /proc/meminfo tdx field is $tdx_meminfo after TDVM lauched"
+      test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests is $tdx_meminfo after TDVM lauched"
     fi
     # shutdown TDVM
     vm_shutdown 10021 "td_pamt" || die "Failed to shutdown TDVM"
     sleep 2
-    # check if TDX KVM host /proc/meminfo tdx field value is zero
-    tdx_meminfo=$(pamt_meminfo_tdx)
+    # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero
+    tdx_meminfo=$(get_dpamt_kb)
     if [ "$tdx_meminfo" -eq 0 ]; then
-      test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after TDVM shutdown"
+      test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after TDVM shutdown"
     else
-      die "TDX KVM host /proc/meminfo tdx field value is not zero after TDVM shutdown, \
+      die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is not zero after TDVM shutdown, \
       please check host kernel pamt enabling setup."
     fi
     ;;
@@ -217,23 +321,23 @@ case $TESTCASE in
     test_print_trc "tdvm 1 launched, VM boot log at /tmp/tdpamt_3/tdvm.1.log"
     # wait for TDVM fully launched for ssh accessible
     vm_up_check 10021
-    # check if TDX KVM host /proc/meminfo tdx field value is zero
-    tdx_meminfo=$(pamt_meminfo_tdx)
+    # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero
+    tdx_meminfo=$(get_dpamt_kb)
     if [ "$tdx_meminfo" -eq 0 ]; then
-      die "TDX KVM host /proc/meminfo tdx field value is still zero after TDVM launch, \
+      die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is still zero after TDVM launch, \
       please check host kernel pamt enabling setup."
     else
-      test_print_trc "TDX KVM host /proc/meminfo tdx field is $tdx_meminfo after TDVM lauched"
+      test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests is $tdx_meminfo after TDVM lauched"
     fi
     # shutdown TDVM
     vm_shutdown 10021 "td_pamt" || die "Failed to shutdown TDVM"
     sleep 2
-    # check if TDX KVM host /proc/meminfo tdx field value is zero
-    tdx_meminfo=$(pamt_meminfo_tdx)
+    # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero
+    tdx_meminfo=$(get_dpamt_kb)
     if [ "$tdx_meminfo" -eq 0 ]; then
-      test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after TDVM shutdown"
+      test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after TDVM shutdown"
     else
-      die "TDX KVM host /proc/meminfo tdx field value is not zero after TDVM shutdown, \
+      die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is not zero after TDVM shutdown, \
       please check host kernel pamt enabling setup."
     fi
     ;;
@@ -248,23 +352,23 @@ case $TESTCASE in
     test_print_trc "tdvm 1 launched, VM boot log at /tmp/tdpamt_4/tdvm.1.log"
     # wait for TDVM fully launched for ssh accessible
     vm_up_check 10021
-    # check if TDX KVM host /proc/meminfo tdx field value is zero
-    tdx_meminfo=$(pamt_meminfo_tdx)
+    # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero
+    tdx_meminfo=$(get_dpamt_kb)
     if [ "$tdx_meminfo" -eq 0 ]; then
-      die "TDX KVM host /proc/meminfo tdx field value is still zero after TDVM launch, \
+      die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is still zero after TDVM launch, \
       please check host kernel pamt enabling setup."
     else
-      test_print_trc "TDX KVM host /proc/meminfo tdx field is $tdx_meminfo after TDVM lauched"
+      test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests is $tdx_meminfo after TDVM lauched"
     fi
     # shutdown TDVM
     vm_shutdown 10021 "td_pamt" || die "Failed to shutdown TDVM"
     sleep 2
-    # check if TDX KVM host /proc/meminfo tdx field value is zero
-    tdx_meminfo=$(pamt_meminfo_tdx)
+    # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero
+    tdx_meminfo=$(get_dpamt_kb)
     if [ "$tdx_meminfo" -eq 0 ]; then
-      test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after TDVM shutdown"
+      test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after TDVM shutdown"
     else
-      die "TDX KVM host /proc/meminfo tdx field value is not zero after TDVM shutdown, \
+      die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is not zero after TDVM shutdown, \
       please check host kernel pamt enabling setup."
     fi
     ;;
@@ -283,33 +387,33 @@ case $TESTCASE in
     # wait for all TDVMs fully launched for ssh accessible
     vm_up_check 10021
     vm_up_check 10022
-    # check if TDX KVM host /proc/meminfo tdx field value is zero
-    tdx_meminfo=$(pamt_meminfo_tdx)
+    # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero
+    tdx_meminfo=$(get_dpamt_kb)
     if [ "$tdx_meminfo" -eq 0 ]; then
-      die "TDX KVM host /proc/meminfo tdx field value is still zero after TDVMs launch, \
+      die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is still zero after TDVMs launch, \
       please check host kernel pamt enabling setup."
     else
-      test_print_trc "TDX KVM host /proc/meminfo tdx field is $tdx_meminfo after TDVMs lauched"
+      test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests is $tdx_meminfo after TDVMs lauched"
     fi
     # shutdown TDVM1
     vm_shutdown 10021 "td_pamt" || die "Failed to shutdown TDVM1"
     sleep 2
-    # check if TDX KVM host /proc/meminfo tdx field value is not zero since TDVM2 is still alive
-    tdx_meminfo=$(pamt_meminfo_tdx)
+    # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is not zero since TDVM2 is still alive
+    tdx_meminfo=$(get_dpamt_kb)
     if [ "$tdx_meminfo" -eq 0 ]; then
-      die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM1 shutdown"
+      die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after TDVM1 shutdown"
     else
-      test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM1 shutdown"
+      test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is $tdx_meminfo after TDVM1 shutdown"
     fi
     # shutdown TDVM2
     vm_shutdown 10022 "td_pamt" || die "Failed to shutdown TDVM2"
     sleep 2
-    # check if TDX KVM host /proc/meminfo tdx field value is zero
-    tdx_meminfo=$(pamt_meminfo_tdx)
+    # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero
+    tdx_meminfo=$(get_dpamt_kb)
     if [ "$tdx_meminfo" -eq 0 ]; then
-      test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after TDVM2 shutdown"
+      test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after TDVM2 shutdown"
     else
-      die "TDX KVM host /proc/meminfo tdx field value is not zero $tdx_meminfo after TDVM2 shutdown, \
+      die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is not zero $tdx_meminfo after TDVM2 shutdown, \
       please check host kernel pamt enabling setup."
     fi
     ;;
@@ -328,33 +432,33 @@ case $TESTCASE in
     # wait for all TDVMs fully launched for ssh accessible
     vm_up_check 10021
     vm_up_check 10022
-    # check if TDX KVM host /proc/meminfo tdx field value is zero
-    tdx_meminfo=$(pamt_meminfo_tdx)
+    # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero
+    tdx_meminfo=$(get_dpamt_kb)
     if [ "$tdx_meminfo" -eq 0 ]; then
-      die "TDX KVM host /proc/meminfo tdx field value is still zero after TDVMs launch, \
+      die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is still zero after TDVMs launch, \
       please check host kernel pamt enabling setup."
     else
-      test_print_trc "TDX KVM host /proc/meminfo tdx field is $tdx_meminfo after TDVMs lauched"
+      test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests is $tdx_meminfo after TDVMs lauched"
     fi
     # shutdown TDVM1
     vm_shutdown 10021 "td_pamt" || die "Failed to shutdown TDVM1"
     sleep 2
-    # check if TDX KVM host /proc/meminfo tdx field value is not zero since TDVM2 is still alive
-    tdx_meminfo=$(pamt_meminfo_tdx)
+    # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is not zero since TDVM2 is still alive
+    tdx_meminfo=$(get_dpamt_kb)
     if [ "$tdx_meminfo" -eq 0 ]; then
-      die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM1 shutdown"
+      die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after TDVM1 shutdown"
     else
-      test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM1 shutdown"
+      test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is $tdx_meminfo after TDVM1 shutdown"
     fi
     # shutdown TDVM2
     vm_shutdown 10022 "td_pamt" || die "Failed to shutdown TDVM2"
     sleep 2
-    # check if TDX KVM host /proc/meminfo tdx field value is zero
-    tdx_meminfo=$(pamt_meminfo_tdx)
+    # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero
+    tdx_meminfo=$(get_dpamt_kb)
     if [ "$tdx_meminfo" -eq 0 ]; then
-      test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after TDVM2 shutdown"
+      test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after TDVM2 shutdown"
     else
-      die "TDX KVM host /proc/meminfo tdx field value is not zero $tdx_meminfo after TDVM2 shutdown, \
+      die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is not zero $tdx_meminfo after TDVM2 shutdown, \
       please check host kernel pamt enabling setup."
     fi
     ;;
@@ -373,33 +477,33 @@ case $TESTCASE in
     # wait for all TDVMs fully launched for ssh accessible
     vm_up_check 10021
     vm_up_check 10022
-    # check if TDX KVM host /proc/meminfo tdx field value is zero
-    tdx_meminfo=$(pamt_meminfo_tdx)
+    # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero
+    tdx_meminfo=$(get_dpamt_kb)
     if [ "$tdx_meminfo" -eq 0 ]; then
-      die "TDX KVM host /proc/meminfo tdx field value is still zero after TDVMs launch, \
+      die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is still zero after TDVMs launch, \
       please check host kernel pamt enabling setup."
     else
-      test_print_trc "TDX KVM host /proc/meminfo tdx field is $tdx_meminfo after TDVMs lauched"
+      test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests is $tdx_meminfo after TDVMs lauched"
     fi
     # shutdown TDVM1
     vm_shutdown 10021 "td_pamt" || die "Failed to shutdown TDVM1"
     sleep 2
-    # check if TDX KVM host /proc/meminfo tdx field value is not zero since TDVM2 is still alive
-    tdx_meminfo=$(pamt_meminfo_tdx)
+    # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is not zero since TDVM2 is still alive
+    tdx_meminfo=$(get_dpamt_kb)
     if [ "$tdx_meminfo" -eq 0 ]; then
-      die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM1 shutdown"
+      die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after TDVM1 shutdown"
     else
-      test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM1 shutdown"
+      test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is $tdx_meminfo after TDVM1 shutdown"
     fi
     # shutdown TDVM2
     vm_shutdown 10022 "td_pamt" || die "Failed to shutdown TDVM2"
     sleep 2
-    # check if TDX KVM host /proc/meminfo tdx field value is zero
-    tdx_meminfo=$(pamt_meminfo_tdx)
+    # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero
+    tdx_meminfo=$(get_dpamt_kb)
     if [ "$tdx_meminfo" -eq 0 ]; then
-      test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after TDVM2 shutdown"
+      test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after TDVM2 shutdown"
     else
-      die "TDX KVM host /proc/meminfo tdx field value is not zero $tdx_meminfo after TDVM2 shutdown, \
+      die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is not zero $tdx_meminfo after TDVM2 shutdown, \
       please check host kernel pamt enabling setup."
     fi
     ;;
@@ -414,23 +518,23 @@ case $TESTCASE in
     test_print_trc "legacy VM launched, VM boot log at /tmp/tdpamt_8/vm.1.log"
     # wait for legacy VM fully launched for ssh accessible
     vm_up_check 10021
-    # check if TDX KVM host /proc/meminfo tdx field value is zero
-    tdx_meminfo=$(pamt_meminfo_tdx)
+    # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero
+    tdx_meminfo=$(get_dpamt_kb)
     if [ "$tdx_meminfo" -eq 0 ]; then
-      test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after legacy VM lauched"
+      test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after legacy VM lauched"
     else
-      die "TDX KVM host /proc/meminfo tdx field value is not zero after legacy VM lauched, \
+      die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is not zero after legacy VM lauched, \
       please check host kernel pamt enabling setup."
     fi
     # shutdown legacy VM
     vm_shutdown 10021 "vm" || die "Failed to shutdown legacy VM"
     sleep 2
-    # check if TDX KVM host /proc/meminfo tdx field value is zero
-    tdx_meminfo=$(pamt_meminfo_tdx)
+    # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero
+    tdx_meminfo=$(get_dpamt_kb)
     if [ "$tdx_meminfo" -eq 0 ]; then
-      test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after legacy VM shutdown"
+      test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after legacy VM shutdown"
     else
-      die "TDX KVM host /proc/meminfo tdx field value is not zero after legacy VM shutdown, \
+      die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is not zero after legacy VM shutdown, \
       please check host kernel pamt enabling setup."
     fi
     ;;
@@ -449,34 +553,34 @@ case $TESTCASE in
     # wait for TDVM and legacy VM fully launched for ssh accessible
     vm_up_check 10021
     vm_up_check 10022
-    # check if TDX KVM host /proc/meminfo tdx field value is zero
-    tdx_meminfo=$(pamt_meminfo_tdx)
+    # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero
+    tdx_meminfo=$(get_dpamt_kb)
     if [ "$tdx_meminfo" -eq 0 ]; then
-      die "TDX KVM host /proc/meminfo tdx field value is still zero after TDVM launch, \
+      die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is still zero after TDVM launch, \
       please check host kernel pamt enabling setup."
     else
-      test_print_trc "TDX KVM host /proc/meminfo tdx field is $tdx_meminfo after TDVM lauched"
+      test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests is $tdx_meminfo after TDVM lauched"
     fi
     # shutdown TDVM
     vm_shutdown 10021 "td_pamt" || die "Failed to shutdown TDVM"
     sleep 2
-    # check if TDX KVM host /proc/meminfo tdx field value is zero
-    tdx_meminfo=$(pamt_meminfo_tdx)
+    # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero
+    tdx_meminfo=$(get_dpamt_kb)
     if [ "$tdx_meminfo" -eq 0 ]; then
-      test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after TDVM shutdown"
+      test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after TDVM shutdown"
     else
-      die "TDX KVM host /proc/meminfo tdx field value is not zero after TDVM shutdown, \
+      die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is not zero after TDVM shutdown, \
       please check host kernel pamt enabling setup."
     fi
     # shutdown legacy VM
     vm_shutdown 10022 "vm" || die "Failed to shutdown legacy VM"
     sleep 2
-    # check if TDX KVM host /proc/meminfo tdx field value is zero
-    tdx_meminfo=$(pamt_meminfo_tdx)
+    # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero
+    tdx_meminfo=$(get_dpamt_kb)
     if [ "$tdx_meminfo" -eq 0 ]; then
-      test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after legacy VM shutdown"
+      test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after legacy VM shutdown"
     else
-      die "TDX KVM host /proc/meminfo tdx field value is not zero after legacy VM shutdown, \
+      die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is not zero after legacy VM shutdown, \
       please check host kernel pamt enabling"
     fi
     ;;
@@ -498,33 +602,33 @@ case $TESTCASE in
       # wait for all TDVMs fully launched for ssh accessible
       vm_up_check 10021
       vm_up_check 10022
-      # check if TDX KVM host /proc/meminfo tdx field value is zero
-      tdx_meminfo=$(pamt_meminfo_tdx)
+      # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero
+      tdx_meminfo=$(get_dpamt_kb)
       if [ "$tdx_meminfo" -eq 0 ]; then
-        die "TDX KVM host /proc/meminfo tdx field value is still zero after TDVMs launch, \
+        die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is still zero after TDVMs launch, \
         please check host kernel pamt enabling setup."
       else
-        test_print_trc "TDX KVM host /proc/meminfo tdx field is $tdx_meminfo after TDVMs lauched"
+        test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests is $tdx_meminfo after TDVMs lauched"
       fi
       # shutdown TDVM1
       vm_shutdown 10021 "td_pamt" || die "Failed to shutdown TDVM1"
       sleep 2
-      # check if TDX KVM host /proc/meminfo tdx field value is not zero since TDVM2 is still alive
-      tdx_meminfo=$(pamt_meminfo_tdx)
+      # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is not zero since TDVM2 is still alive
+      tdx_meminfo=$(get_dpamt_kb)
       if [ "$tdx_meminfo" -eq 0 ]; then
-        die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM1 shutdown"
+        die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after TDVM1 shutdown"
       else
-        test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM1 shutdown"
+        test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is $tdx_meminfo after TDVM1 shutdown"
       fi
       # shutdown TDVM2
       vm_shutdown 10022 "td_pamt" || die "Failed to shutdown TDVM2"
       sleep 2
-      # check if TDX KVM host /proc/meminfo tdx field value is zero
-      tdx_meminfo=$(pamt_meminfo_tdx)
+      # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero
+      tdx_meminfo=$(get_dpamt_kb)
       if [ "$tdx_meminfo" -eq 0 ]; then
-        test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after TDVM2 shutdown"
+        test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after TDVM2 shutdown"
       else
-        die "TDX KVM host /proc/meminfo tdx field value is not zero $tdx_meminfo after TDVM2 shutdown, \
+        die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is not zero $tdx_meminfo after TDVM2 shutdown, \
         please check host kernel pamt enabling setup."
       fi
     done
@@ -560,56 +664,56 @@ case $TESTCASE in
       vm_up_check 10023
       vm_up_check 10024
       vm_up_check 10025
-      # check if TDX KVM host /proc/meminfo tdx field value is zero
-      tdx_meminfo=$(pamt_meminfo_tdx)
+      # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero
+      tdx_meminfo=$(get_dpamt_kb)
       if [ "$tdx_meminfo" -eq 0 ]; then
-        die "TDX KVM host /proc/meminfo tdx field value is still zero after all TDVMs launch, \
+        die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is still zero after all TDVMs launch, \
         please check host kernel pamt enabling setup."
       else
-        test_print_trc "TDX KVM host /proc/meminfo tdx field is $tdx_meminfo after all TDVMs lauched"
+        test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests is $tdx_meminfo after all TDVMs lauched"
       fi
       # shutdown all TDVMs one by one
       vm_shutdown 10021 "td_pamt" || die "Failed to shutdown TDVM1"
       sleep 2
-      # check if TDX KVM host /proc/meminfo tdx field value is not zero since TDVM2, TDVM3, TDVM4 and TDVM5 are still alive
-      tdx_meminfo=$(pamt_meminfo_tdx)
+      # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is not zero since TDVM2, TDVM3, TDVM4 and TDVM5 are still alive
+      tdx_meminfo=$(get_dpamt_kb)
       if [ "$tdx_meminfo" -eq 0 ]; then
-        die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM1 shutdown"
+        die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after TDVM1 shutdown"
       else
-        test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM1 shutdown"
+        test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is $tdx_meminfo after TDVM1 shutdown"
       fi
       vm_shutdown 10022 "td_pamt" || die "Failed to shutdown TDVM2"
       sleep 2
-      tdx_meminfo=$(pamt_meminfo_tdx)
+      tdx_meminfo=$(get_dpamt_kb)
       if [ "$tdx_meminfo" -eq 0 ]; then
-        die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM2 shutdown"
+        die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after TDVM2 shutdown"
       else
-        test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM2 shutdown"
+        test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is $tdx_meminfo after TDVM2 shutdown"
       fi
       vm_shutdown 10023 "td_pamt" || die "Failed to shutdown TDVM3"
       sleep 2
-      tdx_meminfo=$(pamt_meminfo_tdx)
+      tdx_meminfo=$(get_dpamt_kb)
       if [ "$tdx_meminfo" -eq 0 ]; then
-        die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM3 shutdown"
+        die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after TDVM3 shutdown"
       else
-        test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM3 shutdown"
+        test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is $tdx_meminfo after TDVM3 shutdown"
       fi
       vm_shutdown 10024 "td_pamt" || die "Failed to shutdown TDVM4"
       sleep 2
-      tdx_meminfo=$(pamt_meminfo_tdx)
+      tdx_meminfo=$(get_dpamt_kb)
       if [ "$tdx_meminfo" -eq 0 ]; then
-        die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM4 shutdown"
+        die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after TDVM4 shutdown"
       else
-        test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM4 shutdown"
+        test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is $tdx_meminfo after TDVM4 shutdown"
       fi
       vm_shutdown 10025 "td_pamt" || die "Failed to shutdown TDVM5"
       sleep 2
-      # check if TDX KVM host /proc/meminfo tdx field value is zero
-      tdx_meminfo=$(pamt_meminfo_tdx)
+      # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero
+      tdx_meminfo=$(get_dpamt_kb)
       if [ "$tdx_meminfo" -eq 0 ]; then
-        test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after all TDVMs shutdown"
+        test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after all TDVMs shutdown"
       else
-        die "TDX KVM host /proc/meminfo tdx field value is not zero $tdx_meminfo after all TDVMs shutdown, \
+        die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is not zero $tdx_meminfo after all TDVMs shutdown, \
         please check host kernel pamt enabling setup."
       fi
     done
@@ -632,33 +736,33 @@ case $TESTCASE in
       # wait for all TDVMs fully launched for ssh accessible
       vm_up_check 10021
       vm_up_check 10022
-      # check if TDX KVM host /proc/meminfo tdx field value is zero
-      tdx_meminfo=$(pamt_meminfo_tdx)
+      # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero
+      tdx_meminfo=$(get_dpamt_kb)
       if [ "$tdx_meminfo" -eq 0 ]; then
-        die "TDX KVM host /proc/meminfo tdx field value is still zero after TDVMs launch, \
+        die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is still zero after TDVMs launch, \
         please check host kernel pamt enabling setup."
       else
-        test_print_trc "TDX KVM host /proc/meminfo tdx field is $tdx_meminfo after TDVMs lauched"
+        test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests is $tdx_meminfo after TDVMs lauched"
       fi
       # shutdown TDVM1
       vm_shutdown 10021 "td_pamt" || die "Failed to shutdown TDVM1"
       sleep 2
-      # check if TDX KVM host /proc/meminfo tdx field value is not zero since TDVM2 is still alive
-      tdx_meminfo=$(pamt_meminfo_tdx)
+      # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is not zero since TDVM2 is still alive
+      tdx_meminfo=$(get_dpamt_kb)
       if [ "$tdx_meminfo" -eq 0 ]; then
-        die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM1 shutdown"
+        die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after TDVM1 shutdown"
       else
-        test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM1 shutdown"
+        test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is $tdx_meminfo after TDVM1 shutdown"
       fi
       # shutdown TDVM2
       vm_shutdown 10022 "td_pamt" || die "Failed to shutdown TDVM2"
       sleep 2
-      # check if TDX KVM host /proc/meminfo
-      tdx_meminfo=$(pamt_meminfo_tdx)
+      # check if TDX host Dynamic PAMT memory usage for KVM TDX guests
+      tdx_meminfo=$(get_dpamt_kb)
       if [ "$tdx_meminfo" -eq 0 ]; then
-        test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after TDVM2 shutdown"
+        test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after TDVM2 shutdown"
       else
-        die "TDX KVM host /proc/meminfo tdx field value is not zero $tdx_meminfo after TDVM2 shutdown, \
+        die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is not zero $tdx_meminfo after TDVM2 shutdown, \
         please check host kernel pamt enabling setup."
       fi
     done
@@ -694,56 +798,56 @@ case $TESTCASE in
       vm_up_check 10023
       vm_up_check 10024
       vm_up_check 10025
-      # check if TDX KVM host /proc/meminfo tdx field value is zero
-      tdx_meminfo=$(pamt_meminfo_tdx)
+      # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero
+      tdx_meminfo=$(get_dpamt_kb)
       if [ "$tdx_meminfo" -eq 0 ]; then
-        die "TDX KVM host /proc/meminfo tdx field value is still zero after all TDVMs launch, \
+        die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is still zero after all TDVMs launch, \
         please check host kernel pamt enabling setup."
       else
-        test_print_trc "TDX KVM host /proc/meminfo tdx field is $tdx_meminfo after all TDVMs lauched"
+        test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests is $tdx_meminfo after all TDVMs lauched"
       fi
       # shutdown all TDVMs one by one
       vm_shutdown 10021 "td_pamt" || die "Failed to shutdown TDVM1"
       sleep 2
-      # check if TDX KVM host /proc/meminfo tdx field value is not zero since TDVM2, TDVM3, TDVM4 and TDVM5 are still alive
-      tdx_meminfo=$(pamt_meminfo_tdx)
+      # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is not zero since TDVM2, TDVM3, TDVM4 and TDVM5 are still alive
+      tdx_meminfo=$(get_dpamt_kb)
       if [ "$tdx_meminfo" -eq 0 ]; then
-        die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM1 shutdown"
+        die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after TDVM1 shutdown"
       else
-        test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM1 shutdown"
+        test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is $tdx_meminfo after TDVM1 shutdown"
       fi
       vm_shutdown 10022 "td_pamt" || die "Failed to shutdown TDVM2"
       sleep 2
-      tdx_meminfo=$(pamt_meminfo_tdx)
+      tdx_meminfo=$(get_dpamt_kb)
       if [ "$tdx_meminfo" -eq 0 ]; then
-        die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM2 shutdown"
+        die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after TDVM2 shutdown"
       else
-        test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM2 shutdown"
+        test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is $tdx_meminfo after TDVM2 shutdown"
       fi
       vm_shutdown 10023 "td_pamt" || die "Failed to shutdown TDVM3"
       sleep 2
-      tdx_meminfo=$(pamt_meminfo_tdx)
+      tdx_meminfo=$(get_dpamt_kb)
       if [ "$tdx_meminfo" -eq 0 ]; then
-        die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM3 shutdown"
+        die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after TDVM3 shutdown"
       else
-        test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM3 shutdown"
+        test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is $tdx_meminfo after TDVM3 shutdown"
       fi
       vm_shutdown 10024 "td_pamt" || die "Failed to shutdown TDVM4"
       sleep 2
-      tdx_meminfo=$(pamt_meminfo_tdx)
+      tdx_meminfo=$(get_dpamt_kb)
       if [ "$tdx_meminfo" -eq 0 ]; then
-        die "TDX KVM host /proc/meminfo tdx field value is zero after TDVM4 shutdown"
+        die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after TDVM4 shutdown"
       else
-        test_print_trc "TDX KVM host /proc/meminfo tdx field value is $tdx_meminfo after TDVM4 shutdown"
+        test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is $tdx_meminfo after TDVM4 shutdown"
       fi
       vm_shutdown 10025 "td_pamt" || die "Failed to shutdown TDVM5"
       sleep 2
-      # check if TDX KVM host /proc/meminfo tdx field value is zero
-      tdx_meminfo=$(pamt_meminfo_tdx)
+      # check if TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero
+      tdx_meminfo=$(get_dpamt_kb)
       if [ "$tdx_meminfo" -eq 0 ]; then
-        test_print_trc "TDX KVM host /proc/meminfo tdx field value is zero after all TDVMs shutdown"
+        test_print_trc "TDX host Dynamic PAMT memory usage for KVM TDX guests value is zero after all TDVMs shutdown"
       else
-        die "TDX KVM host /proc/meminfo tdx field value is not zero $tdx_meminfo after all TDVMs shutdown, \
+        die "TDX host Dynamic PAMT memory usage for KVM TDX guests value is not zero $tdx_meminfo after all TDVMs shutdown, \
         please check host kernel pamt enabling setup."
       fi
     done
@@ -753,4 +857,13 @@ case $TESTCASE in
     usage && exit 1
     ;;
 esac
+
+if [ "$TESTCASE" -ge 2 ] && [ "$TESTCASE" -le 13 ]; then
+  dpamt_dmesg_check
+fi
+
+if [ "$TESTCASE" -ge 2 ] && [ "$TESTCASE" -le 13 ]; then
+  trap - EXIT
+  dpamt_profile_stop
+fi
 # end of script


### PR DESCRIPTION
since upstream Dynamic PAMT patchset removes /proc/meminfo tdx field for Dynamic PAMT memory accounting implementation, add new function to use ftrace function profiling to calculate Dynamic PAMT memory ussage and enhance to check related kernel failures in dmesg for all Dynamic PAMT functional testcases



(cherry picked from commit 10805269129b063ad20200a97ad395e055622a95)